### PR TITLE
beehive-flow advance-ci unable to push on jenkins

### DIFF
--- a/src/main/ts/commands/Prepare.ts
+++ b/src/main/ts/commands/Prepare.ts
@@ -61,7 +61,7 @@ const createReleaseBranch = async (releaseBranchName: string, git: SimpleGit, di
   await updatePackageJsonFileForReleaseBranch(branchDetails.version, branchDetails.packageJson, branchDetails.packageJsonFile);
   await git.add([ buildPropertiesFile, branchDetails.packageJsonFile ]);
   await git.commit(`Creating release branch: ${releaseBranchName}`);
-  await Git.pushNewBranchUnlessDryRun(dir, git, args.dryRun);
+  await Git.pushExplicitAndSetUpstreamUnlessDryRun(dir, git, args.dryRun);
 };
 
 const updateMainBranch = async (mainBranch: string, git: SimpleGit, branchDetails: BranchDetails, args: PrepareArgs, dir: string): Promise<void> => {

--- a/src/main/ts/commands/Prepare.ts
+++ b/src/main/ts/commands/Prepare.ts
@@ -61,7 +61,7 @@ const createReleaseBranch = async (releaseBranchName: string, git: SimpleGit, di
   await updatePackageJsonFileForReleaseBranch(branchDetails.version, branchDetails.packageJson, branchDetails.packageJsonFile);
   await git.add([ buildPropertiesFile, branchDetails.packageJsonFile ]);
   await git.commit(`Creating release branch: ${releaseBranchName}`);
-  await Git.pushExplicitAndSetUpstreamUnlessDryRun(dir, git, args.dryRun);
+  await Git.pushUnlessDryRun(dir, git, args.dryRun);
 };
 
 const updateMainBranch = async (mainBranch: string, git: SimpleGit, branchDetails: BranchDetails, args: PrepareArgs, dir: string): Promise<void> => {

--- a/src/main/ts/utils/Git.ts
+++ b/src/main/ts/utils/Git.ts
@@ -42,16 +42,13 @@ export const checkoutNewBranch = (git: SimpleGit, branchName: string): Promise<s
 export const currentBranch = (git: SimpleGit): Promise<string> =>
   git.branch().then((b) => b.current);
 
-export const pushExplicitAndSetUpstream = async (git: SimpleGit): Promise<PushResult> => {
+export const push = async (git: SimpleGit): Promise<PushResult> => {
   const cur = await currentBranch(git);
   return git.push(ASSUMED_REMOTE, cur, { '--set-upstream': null });
 };
 
 export const currentRevisionShortSha = (git: SimpleGit): Promise<string> =>
   git.revparse([ '--short', 'HEAD' ]);
-
-export const push = async (git: SimpleGit): Promise<PushResult> =>
-  git.push(ASSUMED_REMOTE);
 
 export const remoteBranchNames = async (git: SimpleGit): Promise<string[]> => {
   const rbs = await git.branch();
@@ -70,14 +67,6 @@ const dryRunMessage = async (dir: string, git: SimpleGit): Promise<string> => {
   return `dry-run - not pushing. To complete, push "${curBranch}" branch from ${dir}`;
 };
 
-export const pushExplicitAndSetUpstreamUnlessDryRun = async (dir: string, git: SimpleGit, dryRun: boolean): Promise<void> => {
-  if (dryRun) {
-    console.log(await dryRunMessage(dir, git));
-  } else {
-    console.log('git push');
-    await pushExplicitAndSetUpstream(git);
-  }
-};
 export const pushUnlessDryRun = async (dir: string, git: SimpleGit, dryRun: boolean): Promise<void> => {
   if (dryRun) {
     console.log(await dryRunMessage(dir, git));

--- a/src/main/ts/utils/Git.ts
+++ b/src/main/ts/utils/Git.ts
@@ -42,7 +42,7 @@ export const checkoutNewBranch = (git: SimpleGit, branchName: string): Promise<s
 export const currentBranch = (git: SimpleGit): Promise<string> =>
   git.branch().then((b) => b.current);
 
-export const pushNewBranch = async (git: SimpleGit): Promise<PushResult> => {
+export const pushExplicitAndSetUpstream = async (git: SimpleGit): Promise<PushResult> => {
   const cur = await currentBranch(git);
   return git.push(ASSUMED_REMOTE, cur, { '--set-upstream': null });
 };
@@ -70,12 +70,12 @@ const dryRunMessage = async (dir: string, git: SimpleGit): Promise<string> => {
   return `dry-run - not pushing. To complete, push "${curBranch}" branch from ${dir}`;
 };
 
-export const pushNewBranchUnlessDryRun = async (dir: string, git: SimpleGit, dryRun: boolean): Promise<void> => {
+export const pushExplicitAndSetUpstreamUnlessDryRun = async (dir: string, git: SimpleGit, dryRun: boolean): Promise<void> => {
   if (dryRun) {
     console.log(await dryRunMessage(dir, git));
   } else {
     console.log('git push');
-    await pushNewBranch(git);
+    await pushExplicitAndSetUpstream(git);
   }
 };
 export const pushUnlessDryRun = async (dir: string, git: SimpleGit, dryRun: boolean): Promise<void> => {

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -33,7 +33,7 @@ describe('Lifecycle', () => {
 
     await git.add('package.json');
     await git.commit('Initial');
-    await Git.pushExplicitAndSetUpstream(git);
+    await Git.push(git);
 
     const assertPjVersion = async (expected: string) => {
       const pj = await PackageJson.parsePackageJsonFileInFolder(dir);

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -33,7 +33,7 @@ describe('Lifecycle', () => {
 
     await git.add('package.json');
     await git.commit('Initial');
-    await Git.pushNewBranch(git);
+    await Git.pushExplicitAndSetUpstream(git);
 
     const assertPjVersion = async (expected: string) => {
       const pj = await PackageJson.parsePackageJsonFileInFolder(dir);

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -91,7 +91,7 @@ describe('Publish', () => {
         await Files.writeFile(pjFile, pjContents);
         await git.add([ npmrcFile, pjFile ]);
         await git.commit('commit');
-        await Git.pushExplicitAndSetUpstream(git);
+        await Git.push(git);
       };
 
       const go = async (version: string, dryRun: boolean) => {

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -91,7 +91,7 @@ describe('Publish', () => {
         await Files.writeFile(pjFile, pjContents);
         await git.add([ npmrcFile, pjFile ]);
         await git.commit('commit');
-        await Git.pushNewBranch(git);
+        await Git.pushExplicitAndSetUpstream(git);
       };
 
       const go = async (version: string, dryRun: boolean) => {

--- a/src/test/ts/core/GitTest.ts
+++ b/src/test/ts/core/GitTest.ts
@@ -17,7 +17,7 @@ const createBranch = async ({ dir, git }: TempGit, branchName: string): Promise<
   fs.writeFileSync(foofile, 'cat cat');
   await git.add(foofile);
   await git.commit('initial');
-  await Git.pushExplicitAndSetUpstream(git);
+  await Git.push(git);
 };
 
 describe('Git', () => {

--- a/src/test/ts/core/GitTest.ts
+++ b/src/test/ts/core/GitTest.ts
@@ -17,7 +17,7 @@ const createBranch = async ({ dir, git }: TempGit, branchName: string): Promise<
   fs.writeFileSync(foofile, 'cat cat');
   await git.add(foofile);
   await git.commit('initial');
-  await Git.pushNewBranch(git);
+  await Git.pushExplicitAndSetUpstream(git);
 };
 
 describe('Git', () => {


### PR DESCRIPTION
Ref: TINY-6821

To address this bug, this PR changes all of our git pushes to specify an explicit upstream branch and use the `--set-upstream` flag. This incantation should work in all situations, so we'll just use it throughout.