### PR TITLE
Change NPM tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ Note: this is the only command that operates on the checkout in the current work
 
 This command does an `npm publish` and sets npm tags based on the repository state.
 
- - All builds get tagged with their branch name 
-   (replacing sequences of characters other than alphanumeric/dot/underscore with dashes)
- - If your repo is on a release branch in "release ready" state, and your release branch has the 
-   greatest version number of all release branches, the build also gets tagged "latest".
+ - main/feature/hotfix/spike branches are tagged with their branch name
+ - release branches in prerelease state are tagged `rc-a.b`
+ - release branches in release state are tagged `release-a.b`. 
+ - release branches in release state are also tagged `latest` if this is the release with the highest version number.
 
 Note: it appears that npm also tags the very first published build of each repo with "latest". 
 

--- a/src/main/ts/commands/Publish.ts
+++ b/src/main/ts/commands/Publish.ts
@@ -11,7 +11,7 @@ export const publish = async (args: PublishArgs): Promise<void> => {
   const git = gitP(dir);
   const r = await getBranchDetails(dir);
 
-  const tags = await NpmTags.pickTagsGit(r.currentBranch, r.branchState, git);
+  const tags = await NpmTags.pickTagsGit(r.currentBranch, r.branchState, r.version, git);
   const [ mainTag ] = tags;
 
   const dryRunArgs = args.dryRun ? [ '--dry-run' ] : [];

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -3,25 +3,33 @@ import * as Git from '../utils/Git';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import * as ArrayUtils from '../utils/ArrayUtils';
 import { BranchState, getReleaseBranchName, versionFromReleaseBranch } from './BranchLogic';
-import * as Version from './Version';
+import { compareMajorMinorVersions, majorMinorVersionToString, Version } from './Version';
 
-const normalize = (branchName: string): string =>
-  branchName.replace(/[^\w.]+/g, '-');
-
-export const pickTags = async (branchName: string, branchState: BranchState, getBranches: () => Promise<string[]>): Promise<[string, string?]> => {
-  const mainTag = normalize(branchName);
-
-  if (branchState !== BranchState.ReleaseReady) {
-    return [ mainTag ];
-  }
-
+const isLatestReleaseBranch = async (getBranches: () => Promise<string[]>, branchName: string): Promise<boolean> => {
   const branches = await getBranches();
   const versions = await PromiseUtils.filterMap(branches, versionFromReleaseBranch);
-  const greatestOpt = ArrayUtils.greatest(versions, Version.compareMajorMinorVersions);
+  const greatestOpt = ArrayUtils.greatest(versions, compareMajorMinorVersions);
   const greatest = await PromiseUtils.optionToPromise(greatestOpt, 'Could not find any release branches with valid names.');
   const releaseBranchName = getReleaseBranchName(greatest);
-  return branchName === releaseBranchName ? [ mainTag, 'latest' ] : [ mainTag ];
+  return branchName === releaseBranchName;
 };
 
-export const pickTagsGit = async (branchName: string, branchState: BranchState, git: SimpleGit): Promise<[string, string?]> =>
-  pickTags(branchName, branchState, () => Git.remoteBranchNames(git));
+export const pickTags = async (branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>): Promise<string[]> => {
+
+  const mainTag = branchName.replace(/[^\w.]+/g, '-');
+
+  if (branchState === BranchState.ReleaseCandidate) {
+    const vs = majorMinorVersionToString(version);
+    return [ `rc-${vs}` ];
+
+  } else if (branchState === BranchState.ReleaseReady) {
+    const isLatest = await isLatestReleaseBranch(getBranches, branchName);
+    return isLatest ? [ mainTag, 'latest' ] : [ mainTag ];
+
+  } else {
+    return [ mainTag ];
+  }
+};
+
+export const pickTagsGit = async (branchName: string, branchState: BranchState, version: Version, git: SimpleGit): Promise<string[]> =>
+  pickTags(branchName, branchState, version, () => Git.remoteBranchNames(git));

--- a/src/test/ts/core/NpmTagsTest.ts
+++ b/src/test/ts/core/NpmTagsTest.ts
@@ -4,70 +4,78 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as NpmTags from '../../../main/ts/core/NpmTags';
 import { BranchState } from '../../../main/ts/core/BranchLogic';
 import * as PromiseUtils from '../../../main/ts/utils/PromiseUtils';
+import { parseVersion } from '../../../main/ts/core/Version';
 
 const assert = chai.use(chaiAsPromised).assert;
 const succeed = PromiseUtils.succeed;
 
-const checkSimple = async (branchName: string, branchState: BranchState, branchTagName: string): Promise<void> => {
+const checkSimple = async (branchName: string, branchState: BranchState, version: string, branchTagName: string): Promise<void> => {
+  const v = await parseVersion(version);
   await assert.becomes(
-    NpmTags.pickTags(branchName, branchState, PromiseUtils.fail),
+    NpmTags.pickTags(branchName, branchState, v, PromiseUtils.fail),
     [ branchTagName ]
   );
 };
 
 describe('NpmTags', () => {
   describe('pickTags', () => {
-    it('uses the branch name for feature branches', () => checkSimple('feature/BLAH-123', BranchState.Feature, 'feature-BLAH-123'));
-    it('uses the branch name for spike branches', () => checkSimple('spike/BLAH-123', BranchState.Spike, 'spike-BLAH-123'));
-    it('uses the branch name for hotfix branches', () => checkSimple('hotfix/BLAH-123', BranchState.Hotfix, 'hotfix-BLAH-123'));
-    it('uses the branch name for main branch', () => checkSimple('main', BranchState.ReleaseCandidate, 'main'));
-    it('uses the branch name for rc state', () => checkSimple('hotfix/BLAH-123', BranchState.ReleaseCandidate, 'hotfix-BLAH-123'));
+    it('uses the branch name for feature branches', () => checkSimple('feature/BLAH-123', BranchState.Feature, '0.1.0', 'feature-BLAH-123'));
+    it('uses the branch name for spike branches', () => checkSimple('spike/BLAH-123', BranchState.Spike, '0.1.7', 'spike-BLAH-123'));
+    it('uses the branch name for hotfix branches', () => checkSimple('hotfix/BLAH-123', BranchState.Hotfix, '0.1.9', 'hotfix-BLAH-123'));
+    it('uses the branch name for main branch', () => checkSimple('main', BranchState.Main, '0.1.2', 'main'));
+
+    it('uses the branch name and rc-version for rc state', async () => {
+      await assert.becomes(
+        NpmTags.pickTags('release/9.12', BranchState.ReleaseCandidate, await parseVersion('9.12.0-rc'), () => succeed([ 'release/9.12' ])),
+        [ 'rc-9.12' ]
+      );
+    });
 
     it('replaces sequences of characters other than alphanumeric/dot/underscore with dashes', () =>
-      checkSimple('hotfix/blah_32.7/b**@', BranchState.ReleaseCandidate, 'hotfix-blah_32.7-b-')
+      checkSimple('hotfix/blah_32.7/b**@', BranchState.Hotfix, '0.1.2', 'hotfix-blah_32.7-b-')
     );
 
     it('uses the branch name (replacing multiple slashes feature branches',
-      () => checkSimple('feature/BLAH/12/3', BranchState.Feature, 'feature-BLAH-12-3')
+      () => checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', 'feature-BLAH-12-3')
     );
 
-    it('uses the branch name for release ready state if not the latest release branch', async () => {
+    it('uses no tags for release ready state if not the latest release branch', async () => {
       await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, () => succeed([ 'release/1.3' ])),
+        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.6'), () => succeed([ 'release/1.2', 'release/1.7' ])),
         [ 'release-1.2' ]
       );
       await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, () => succeed([ 'release/1.2', 'release/1.3', 'main' ])),
+        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.9'), () => succeed([ 'release/1.2', 'release/1.3', 'main' ])),
         [ 'release-1.2' ]
       );
       await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, () => succeed([ 'release/2.0', 'feature/1.2' ])),
+        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.92'), () => succeed([ 'release/2.0', 'feature/1.2' ])),
         [ 'release-1.2' ]
       );
     });
 
-    it('uses the branch name and "latest" for release ready state if it is the latest release branch', async () => {
+    it('uses "latest" for release ready state if it is the latest release branch', async () => {
       await assert.becomes(
-        NpmTags.pickTags('release/6.7', BranchState.ReleaseReady,
+        NpmTags.pickTags('release/6.7', BranchState.ReleaseReady, await parseVersion('6.7.22'),
           () => succeed([ 'main', 'frog', 'release/6.7', 'release/6.6', 'feature/1.2' ])),
         [ 'release-6.7', 'latest' ]
       );
 
       await assert.becomes(
-        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady,
+        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.0'),
           () => succeed([ 'release/8.1', 'main', 'frog', 'release/6.7', 'release/8.0', 'release/6.6', 'feature/1.2' ])),
         [ 'release-8.1', 'latest' ]
       );
 
       await assert.becomes(
-        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady,
+        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.12'),
           () => succeed([ 'main', 'frog', 'release/6.7', 'release/6.6', 'feature/1.2', 'release/8.1' ])),
         [ 'release-8.1', 'latest' ]
       );
     });
 
     it('fails if no release branches can be found', async () => {
-      await assert.isRejected(NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, () => succeed([])));
+      await assert.isRejected(NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.11'), () => succeed([])));
     });
   });
 });


### PR DESCRIPTION
Ref: TINY-6825

Currently we tag all of release/x.y branches as “release-x.y”. This is weird when it’s on an RC build. Instead: 
- tag the rc builds as “rc-x.y”.
- tag the release builds as “release-x.y”