### PR TITLE
Publishing from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.12.0] - unreleased
+- publish from main branch
+- tag greatest prerelease version as latest if no prior release versions
+- change output of status command
+
 ## [0.11.0] - 2021-01-11
 ### Added
 - `beehive-flow publish --dist-dir` setting

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To make changes to a `release/x.y` branch, create a `hotfix/*` branch, cherry-pi
 ```
 
 The `main` and `release/x.y` branches can either be in a "release candidate" state with a version like `x.y.z-rc`, or
-a "release ready" state with a version like `x.y.z-rc`. This affects what version is published from CI.
+a "release ready" state with a version like `x.y.z`. This affects what version is published from CI.
 
 `beehive-flow release` changes a branch from an rc version to a release version e.g. `1.2.3-rc` -> `1.2.3`. 
 When CI encounters this, a release version is published. 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ When publishing, `beehive-flow` reads the existing NPM tags from the repo and us
 to set `latest` on the new build. `latest` is set if the new build's number is "greater" than the existing build. 
 
 Note that all release builds are considered greater than all rc builds. So, for a new project, you may have a period
-where your `latest` tag only points to `rc` builds, but after your first release, `latest` will point to a release build.
+where your `latest` tag only points to `rc` builds, but after your first release, `latest` will always point to a release build.
 
 Note that the first publish of a build is always tagged `latest`.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ beehive-flow uses the following branch names, each forming part of the process:
  - hotfix/FEATURE_CODE
  - spike/FEATURE_CODE
 
-Branch names and versioning is strict and enforced.
+Branch names and versions are strict and enforced.
 
 All new work happens in `feature/*` branches which are merged to the `main` branch:
 
@@ -38,7 +38,6 @@ All new work happens in `feature/*` branches which are merged to the `main` bran
 The `main` branch is branched to `release/x.y` branches to stabilise a minor version. This is done with `beehive-flow prepare`:
 
 ```
-                       
   main                 
  (1.2.0-rc)           (1.3.0-rc)
   +-----------------+--------------------                             
@@ -63,7 +62,7 @@ To make changes to a `release/x.y` branch, create a `hotfix/*` branch, cherry-pi
             (1.2.0-rc)
 ```
 
-The `main` and `release/x.y` branches can either be a "release candidate" state with a version like `x.y.z-rc`, or
+The `main` and `release/x.y` branches can either be in a "release candidate" state with a version like `x.y.z-rc`, or
 a "release ready" state with a version like `x.y.z-rc`. This affects what version is published from CI.
 
 `beehive-flow release` changes a branch from an rc version to a release version e.g. `1.2.3-rc` -> `1.2.3`. 

--- a/README.md
+++ b/README.md
@@ -203,12 +203,11 @@ The timestamping changes the package.json file. The idea is to build and publish
 
 Versions are changed thus:
 
- - On the main branch, `a.b.0-alpha` becomes `a.b.0-alpha.TIMESTAMP.GITSHA`
  - On a feature branch, `a.b.0-*` becomes `a.b.0-feature.TIMESTAMP.GITSHA`
  - On a hotfix branch, `a.b.c-*` becomes `a.b.c-hotfix.TIMESTAMP.GITSHA`
  - On a spike branch, `a.b.c-*` becomes `a.b.c-spike.TIMESTAMP.GITSHA`
- - On a release branch in prerelease state, `a.b.c-rc` becomes `a.b.c-rc.TIMESTAMP.GITSHA`
- - On a release branch in release state, no changes are made.
+ - On a main or release branch in rc state, `a.b.c-rc` becomes `a.b.c-rc.TIMESTAMP.GITSHA`
+ - On a main or release branch in release state, no changes are made.
  
 Timestamp format is `yyyyMMddHHmmssSSS` in UTC. The short git sha format is used.
 
@@ -218,12 +217,22 @@ Note: this is the only command that operates on the checkout in the current work
 
 This command does an `npm publish` and sets npm tags based on the repository state.
 
- - main/feature/hotfix/spike branches are tagged with their branch name
- - release branches in prerelease state are tagged `rc-a.b`
- - release branches in release state are tagged `release-a.b`. 
- - release branches in release state are also tagged `latest` if this is the release with the highest version number.
+ - feature/hotfix/spike branches are tagged with their branch name
+ - main and release branches in rc state are tagged `rc-a.b`
+ - main and release branches in release state are tagged `release-a.b`. 
+ - main and release branches in rc or release state are also tagged `latest` if this is the release with the highest version number.
 
-Note: it appears that npm also tags the very first published build of each repo with "latest". 
+`beehive-flow publish` also git tags any release builds as `packagename@version`. 
+
+#### Determining the `latest` build
+
+When publishing, `beehive-flow` reads the existing NPM tags from the repo and uses those to determine whether or not
+to set `latest` on the new build. `latest` is set if the new build's number is "greater" than the existing build. 
+
+Note that all release builds are considered greater than all rc builds. So, for a new project, you may have a period
+where your `latest` tag only points to `rc` builds, but after your first release, `latest` will point to a release build.
+
+Note that the first publish of a build is always tagged `latest`.
 
 ### status
 
@@ -247,7 +256,7 @@ $ yarn --silent beehive-flow status
   "versionString": "0.11.0-rc",
   "branchType": "feature",
   "branchState": "feature",
-  "isLatestReleaseBranch": false
+  "isLatest": false
 }
 ```
 
@@ -261,7 +270,7 @@ Fields:
  - branchType - one of: `main`, `feature`, `hotfix`, `spike`, `release`
  - branchState - state of the branch - similar to branchType, but splits release branches into 2 separate states. 
    May be one of: `main`, `feature`, `hotfix`, `spike`, `releaseCandidate`, `releaseReady`
- - isLatestReleaseBranch - Is this a release branch, and is it the _latest_ release branch? If `true`, this is the state where beehive-flow would npm tag the build as `latest`.
+ - isLatest - If this version were to be published, would it be the `latest` build?
 
 If you want to read this from a Jenkinsfile:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All new work happens in `feature/*` branches which are merged to the `main` bran
 ```
                        feature/BLAH-123
   main                 +-----------
- (x.y.0-alpha)         |           \
+ (x.y.0-rc)            |           \
   +--------------------+------------+-----
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ def beehiveFlowStatus = shJson("yarn run --silent beehive-flow status");
 Then, if you want to run something when beehive-flow would publish a new release build of the latest release:
 
 ```
-if (beehiveFlowStatus.branchState == 'releaseReady' && beehiveFlowStatus.isLatestReleaseBranch) {
+if (beehiveFlowStatus.branchState == 'releaseReady' && beehiveFlowStatus.isLatest) {
 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The testers can then test the new version, while other developers begin work on 
 
 Key aspects:
 - releasing only from `release/x.y`
-- stabilising *before* release 
+- stabilising *before* release
 
 This process is suitable for the following scenarios:
 - projects focused on new feature releases

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This command is similar to `advance`, however:
 This command should be run at the start of a build. This command does the following:
 
  1. Checks that the package.json file has a valid version for the branch.
- 2. Changes the version to a "timestamped" version, so that each build can be published.
+ 2. Changes the version to a "timestamped" version, so that each build can be published (except for release versions).
  
 The timestamping changes the package.json file. The idea is to build and publish, but not to commit the changes.
 
@@ -211,7 +211,7 @@ Versions are changed thus:
  
 Timestamp format is `yyyyMMddHHmmssSSS` in UTC. The short git sha format is used.
 
-Note: this is the only command that operates on the checkout in the current working directory.
+Note: this command operates on the checkout in the current working directory.
 
 ### publish
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ Support for monorepos using yarn workspaces is planned.
 ## Key concepts
 
 - All new work happens in `feature/*` branches which are merged to the `main` branch.
-- The `main` branch is branched to `release/x.y` branches to produce release candidates and releases.
+- The `main` branch is branched to `release/x.y` branches to stabilise a minor version. This can be done either before or after the minor version is released.
+- Release can be done from `main` or `release/x.y`.
+- `main` and `release/x.y` branches can be in "release candidate" or "release ready" state.
 - `hotfix/*` branches are used to make updates to `release/x.y` branches.
 - The `beehive-flow` CLI tool defines several commands, used to perform key actions involved in branching and releasing.
+- As above, publishing can happen from any branch.
+- Branch naming and versioning is strict and enforced.
 
 ## Branches
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ When the team is ready to work on the next minor release, they run `beehive-flow
 This creates the `release/x.y` branch that the team uses to backport fixes to old releases.
 
 Key aspects: 
-- releasing from main
+- releasing from `main` and `release/x.y` branches
 - stabilising *after* release
 
 This process is suitable for the following scenarios:

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "version": "0.12.0-alpha",
+  "version": "0.12.0-rc",
   "name": "@tinymce/beehive-flow"
 }

--- a/src/main/ts/args/BeehiveArgs.ts
+++ b/src/main/ts/args/BeehiveArgs.ts
@@ -1,5 +1,4 @@
 import { Option } from 'fp-ts/Option';
-import { MajorMinorVersion } from '../core/Version';
 
 export interface BaseArgs {
   readonly dryRun: boolean;
@@ -15,14 +14,14 @@ export interface PrepareArgs extends BaseArgs {
 export interface ReleaseArgs extends BaseArgs {
   readonly kind: 'ReleaseArgs';
   readonly temp: Option<string>;
-  readonly majorMinorVersion: MajorMinorVersion;
+  readonly branchName: string;
   readonly gitUrl: Option<string>;
 }
 
 export interface AdvanceArgs extends BaseArgs {
   readonly kind: 'AdvanceArgs';
   readonly temp: Option<string>;
-  readonly majorMinorVersion: MajorMinorVersion;
+  readonly branchName: string;
   readonly gitUrl: Option<string>;
 }
 
@@ -52,25 +51,25 @@ export const prepareArgs = (dryRun: boolean, workingDir: string, temp: Option<st
 });
 
 export const releaseArgs = (
-  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, majorMinorVersion: MajorMinorVersion
+  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string
 ): ReleaseArgs => ({
   kind: 'ReleaseArgs',
   dryRun,
   workingDir,
   temp,
   gitUrl,
-  majorMinorVersion
+  branchName
 });
 
 export const advanceArgs = (
-  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, majorMinorVersion: MajorMinorVersion
+  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string
 ): AdvanceArgs => ({
   kind: 'AdvanceArgs',
   dryRun,
   workingDir,
   temp,
   gitUrl,
-  majorMinorVersion
+  branchName
 });
 
 export const stampArgs = (dryRun: boolean, workingDir: string): StampArgs => ({

--- a/src/main/ts/args/Parser.ts
+++ b/src/main/ts/args/Parser.ts
@@ -2,8 +2,8 @@ import * as yargs from 'yargs';
 import * as O from 'fp-ts/Option';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { parseMajorMinorVersion } from '../core/Version';
-import * as BeehiveArgs from './BeehiveArgs';
 import * as BranchLogic from '../core/BranchLogic';
+import * as BeehiveArgs from './BeehiveArgs';
 
 type BeehiveArgs = BeehiveArgs.BeehiveArgs;
 type Option<A> = O.Option<A>;
@@ -146,7 +146,7 @@ export const parseArgs = async (args: string[]): Promise<Option<BeehiveArgs>> =>
       const mm = await parseMajorMinorVersion(mmm);
       return BranchLogic.getReleaseBranchName(mm);
     }
-  }
+  };
 
   if (cmd === 'prepare') {
     return O.some(BeehiveArgs.prepareArgs(dryRun, workingDir, temp(), gitUrl()));

--- a/src/main/ts/commands/Advance.ts
+++ b/src/main/ts/commands/Advance.ts
@@ -3,7 +3,7 @@ import { SimpleGit } from 'simple-git';
 import { AdvanceArgs, AdvanceCiArgs, BeehiveArgs } from '../args/BeehiveArgs';
 import { Version, versionToString } from '../core/Version';
 import * as Git from '../utils/Git';
-import { BranchState, getReleaseBranchName, getBranchDetails } from '../core/BranchLogic';
+import { BranchState, getBranchDetails } from '../core/BranchLogic';
 import { PackageJson, writePackageJsonFileWithNewVersion } from '../core/PackageJson';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { releaseCandidate } from '../core/PreRelease';
@@ -33,8 +33,7 @@ export const advance = async (args: AdvanceArgs): Promise<void> => {
 
   const { dir, git } = await Git.cloneInTempFolder(gitUrl, args.temp);
 
-  const rbn = getReleaseBranchName(args.majorMinorVersion);
-  await Git.checkout(git, rbn);
+  await Git.checkout(git, args.branchName);
 
   const branchDetails = await getBranchDetails(dir);
   if (branchDetails.branchState !== BranchState.ReleaseReady) {

--- a/src/main/ts/commands/Prepare.ts
+++ b/src/main/ts/commands/Prepare.ts
@@ -9,7 +9,7 @@ import * as Files from '../utils/Files';
 import { PrepareArgs } from '../args/BeehiveArgs';
 import { Version } from '../core/Version';
 import * as PromiseUtils from '../utils/PromiseUtils';
-import * as Prerelease from '../core/PreRelease';
+import * as PreRelease from '../core/PreRelease';
 import { printHeaderMessage } from '../core/Messages';
 
 type PackageJson = PackageJson.PackageJson;
@@ -32,14 +32,14 @@ export const newMainBranchVersion = (oldMainBranchVersion: Version): Version => 
   major: oldMainBranchVersion.major,
   minor: oldMainBranchVersion.minor + 1,
   patch: 0,
-  preRelease: Prerelease.mainBranch
+  preRelease: PreRelease.releaseCandidate
 });
 
 export const releaseBranchVersion = (oldMainBranchVersion: Version): Version => ({
   major: oldMainBranchVersion.major,
   minor: oldMainBranchVersion.minor,
   patch: 0,
-  preRelease: Prerelease.releaseCandidate
+  preRelease: PreRelease.releaseCandidate
 });
 
 const updatePackageJsonFileForReleaseBranch = async (version: Version, pj: PackageJson, pjFile: string): Promise<void> => {
@@ -83,8 +83,8 @@ export const prepare = async (args: PrepareArgs): Promise<void> => {
   const mainBranch = await Git.checkoutMainBranch(git);
 
   const branchDetails = await getBranchDetails(dir);
-  if (branchDetails.branchState !== BranchState.Main) {
-    return PromiseUtils.fail('main branch not in correct state.');
+  if (branchDetails.branchState !== BranchState.ReleaseCandidate) {
+    return PromiseUtils.fail('main branch should have a prerelease version when running this command');
   }
 
   const releaseBranchName = getReleaseBranchName(branchDetails.version);

--- a/src/main/ts/commands/Prepare.ts
+++ b/src/main/ts/commands/Prepare.ts
@@ -84,7 +84,7 @@ export const prepare = async (args: PrepareArgs): Promise<void> => {
 
   const branchDetails = await getBranchDetails(dir);
   if (branchDetails.branchState !== BranchState.ReleaseCandidate) {
-    return PromiseUtils.fail('main branch should have a prerelease version when running this command');
+    return PromiseUtils.fail('main branch should have an rc version when running this command');
   }
 
   const releaseBranchName = getReleaseBranchName(branchDetails.version);

--- a/src/main/ts/commands/Publish.ts
+++ b/src/main/ts/commands/Publish.ts
@@ -14,7 +14,7 @@ export const publish = async (args: PublishArgs): Promise<void> => {
   const git = gitP(dir);
   const r = await getBranchDetails(dir);
 
-  const tags = await NpmTags.pickTagsGit(r.currentBranch, r.branchState, r.version, git);
+  const tags = await NpmTags.pickTagsNpm(r.currentBranch, r.branchState, r.version, dir, r.packageJson.name);
   const [ mainTag ] = tags;
 
   const dryRunArgs = args.dryRun ? [ '--dry-run' ] : [];

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -3,7 +3,7 @@ import * as Version from '../core/Version';
 import * as Git from '../utils/Git';
 import * as PackageJson from '../core/PackageJson';
 import * as PromiseUtils from '../utils/PromiseUtils';
-import { BranchState, getBranchDetails, getReleaseBranchName } from '../core/BranchLogic';
+import { BranchState, getBranchDetails } from '../core/BranchLogic';
 import { printHeaderMessage } from '../core/Messages';
 
 type Version = Version.Version;
@@ -21,8 +21,7 @@ export const release = async (args: ReleaseArgs): Promise<void> => {
 
   const { dir, git } = await Git.cloneInTempFolder(gitUrl, args.temp);
 
-  const rbn = getReleaseBranchName(args.majorMinorVersion);
-  await Git.checkout(git, rbn);
+  await Git.checkout(git, args.branchName);
 
   const branchDetails = await getBranchDetails(dir);
   if (branchDetails.branchState !== BranchState.ReleaseCandidate) {

--- a/src/main/ts/commands/Stamp.ts
+++ b/src/main/ts/commands/Stamp.ts
@@ -22,10 +22,8 @@ export const chooseNewVersion = (branchState: BranchState, version: Version, git
 
     const prePre = (() => {
       switch (branchState) {
-        case BranchState.Main:
-          return PreRelease.mainBranch;
         case BranchState.ReleaseCandidate:
-          return PreRelease.releaseCandidate;
+          return version.preRelease;
         case BranchState.Feature:
           return PreRelease.featureBranch;
         case BranchState.Hotfix:

--- a/src/main/ts/commands/Status.ts
+++ b/src/main/ts/commands/Status.ts
@@ -1,8 +1,7 @@
-import * as gitP from 'simple-git/promise';
 import { StatusArgs } from '../args/BeehiveArgs';
 import * as BranchLogic from '../core/BranchLogic';
-import * as Git from '../utils/Git';
 import * as Version from '../core/Version';
+import * as NpmTags from '../core/NpmTags';
 
 type BranchState = BranchLogic.BranchState;
 type BranchType = BranchLogic.BranchType;
@@ -14,7 +13,7 @@ export interface Status {
   versionString: string;
   branchType: BranchType;
   branchState: BranchState;
-  isLatestReleaseBranch: boolean;
+  isLatest: boolean;
 }
 
 export const status = async (args: StatusArgs): Promise<void> => {
@@ -29,12 +28,10 @@ export const getStatusJson = async (args: StatusArgs): Promise<string> => {
 
 export const getStatus = async (args: StatusArgs): Promise<Status> => {
   const dir = args.workingDir;
-  const git = gitP(dir);
 
-  const { currentBranch, version, branchState, branchType } = await BranchLogic.getBranchDetails(dir);
-  const branchNames = await Git.remoteBranchNames(git);
+  const { currentBranch, version, branchState, branchType, packageJson } = await BranchLogic.getBranchDetails(dir);
 
-  const isLatestReleaseBranch = await BranchLogic.isLatestReleaseBranch(currentBranch, branchNames);
+  const isLatest = await NpmTags.shouldTagLatestNpm(version, dir, packageJson.name);
 
   return {
     currentBranch,
@@ -42,6 +39,6 @@ export const getStatus = async (args: StatusArgs): Promise<Status> => {
     versionString: Version.versionToString(version),
     branchType,
     branchState,
-    isLatestReleaseBranch
+    isLatest
   };
 };

--- a/src/main/ts/core/BranchLogic.ts
+++ b/src/main/ts/core/BranchLogic.ts
@@ -1,11 +1,9 @@
 import * as O from 'fp-ts/Option';
 import * as gitP from 'simple-git/promise';
 import { CheckRepoActions } from 'simple-git';
-import { pipe } from 'fp-ts/pipeable';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { showStringOrUndefined } from '../utils/StringUtils';
 import * as Git from '../utils/Git';
-import * as ArrayUtils from '../utils/ArrayUtils';
 import * as Version from './Version';
 import * as PreRelease from './PreRelease';
 import * as PackageJson from './PackageJson';
@@ -164,11 +162,3 @@ export const getBranchDetails = async (dir: string): Promise<BranchDetails> => {
   }
 };
 
-export const isLatestReleaseBranch = async (branchName: string, branches: string[]): Promise<boolean> => {
-  const versions = await PromiseUtils.filterMap(branches, versionFromReleaseBranch);
-  return pipe(
-    ArrayUtils.greatest(versions, Version.compareMajorMinorVersions),
-    O.map(getReleaseBranchName),
-    O.exists((greatest) => branchName === greatest)
-  );
-};

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -1,12 +1,26 @@
-import { SimpleGit } from 'simple-git/promise';
-import * as Git from '../utils/Git';
+import { pipe } from 'fp-ts/pipeable';
+import * as O from 'fp-ts/Option';
+import * as cs from 'cross-spawn-promise';
 import * as PreRelease from '../core/PreRelease';
-import { BranchState, isLatestReleaseBranch } from './BranchLogic';
-import { majorMinorVersionToString, Version } from './Version';
+import { isGte } from '../utils/Comparison';
+import * as PromiseUtils from '../utils/PromiseUtils';
+import { BranchState } from './BranchLogic';
+import { compareVersions, isPreRelease, majorMinorVersionToString, parseVersion, Version } from './Version';
 
+/**
+ * Pick NPM tags for the release. There are 3 types of tags:
+ *
+ * - branch tag: tags based on branch name. On everything except RC builds on release branches.
+ * - rc tags: rc-x.y - used on rc builds
+ * - latest tag: used on the latest build
+ *
+ * Note: we tag releases as release-x.y. This seems unnecessary, as you can use package@x.y to refer to it.
+ * However, we need to pick at least one tag for each build, otherwise npm publish will tag builds as 'latest'.
+ * Adding the release-x.y tag covers a few scenarios where we don't otherwise have a tag to add.
+*/
 export const pickTags = async (
-  branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>
-): Promise<[string, ...string[]]> => {
+  branchName: string, branchState: BranchState, version: Version, npmTags: () => Promise<NpmTags>
+): Promise<[ string, ...string[] ]> => {
 
   const branchTag = branchName.replace(/[^\w.]+/g, '-');
 
@@ -14,31 +28,73 @@ export const pickTags = async (
 
   const rcTagName = () => `${PreRelease.releaseCandidate}-${vs}`;
 
-  // Note: we tag releases as release-x.y. This seems unnecessary, as you can use package@x.y to refer to it.
-  // However, we need to pick at least one tag for each build, otherwise npm publish will tag builds as 'latest'.
-  // Adding this tag covers a few scenarios where we don't otherwise have a tag to add.
-
-  if (branchName === 'main') {
-    if (branchState === BranchState.ReleaseCandidate) {
-      return [ branchTag, rcTagName() ];
-
-    } else if (branchState === BranchState.ReleaseReady) {
-      // assume main is always latest minor version
-      return [ branchTag, 'latest', `release-${vs}` ];
+  const latestTags = await (async () => {
+    if (branchState === BranchState.ReleaseCandidate || branchState === BranchState.ReleaseReady) {
+      const tags = await npmTags();
+      if (shouldTagLatest(version, tags)) {
+        return [ 'latest' ];
+      }
     }
+    return [];
+  })();
 
-  } else {
-    if (branchState === BranchState.ReleaseCandidate) {
+  const mainTags = ((): [string, ...string[]] => {
+    if (branchName === 'main') {
+      if (branchState === BranchState.ReleaseCandidate) {
+        return [ branchTag, rcTagName() ];
+
+      } else if (branchState === BranchState.ReleaseReady) {
+        return [ branchTag, `release-${vs}` ];
+      }
+
+    } else if (branchState === BranchState.ReleaseCandidate) {
       // tagging a prerelease as release-x.y would be confusing
       return [ rcTagName() ];
-
-    } else if (branchState === BranchState.ReleaseReady) {
-      const isLatest = await isLatestReleaseBranch(branchName, await getBranches());
-      return isLatest ? [ branchTag, 'latest' ] : [ branchTag ];
     }
-  }
-  return [ branchTag ];
+    return [ branchTag ];
+  })();
+
+  return [ ...mainTags, ...latestTags ];
 };
 
-export const pickTagsGit = async (branchName: string, branchState: BranchState, version: Version, git: SimpleGit): Promise<[string, ...string[]]> =>
-  pickTags(branchName, branchState, version, () => Git.remoteBranchNames(git));
+export const pickTagsNpm = (branchName: string, branchState: BranchState, version: Version, dir: string, packageName: string) =>
+  pickTags(branchName, branchState, version, () => getNpmTagsOrNone(dir, packageName));
+
+export type NpmTags = Record<string, Version>;
+
+/**
+ * If a package hasn't been published before, getNpmTags will fail. However, we need a list of tags for the first publish.
+ * This function falls back to an empty list of tags if getNpmTags fails.
+ */
+export const getNpmTagsOrNone = (cwd: string, packageName: string): Promise<NpmTags> =>
+  PromiseUtils.getOrElse(getNpmTags(cwd, packageName), {});
+
+export const getNpmTags = async (cwd: string, packageName: string): Promise<NpmTags> => {
+  const output = await cs('npm', [ 'dist-tag', 'ls', packageName ], { cwd });
+  const lines = output.toString().split('\n').filter((x) => x.length > 0);
+  const r: Record<string, Version> = {};
+
+  for (const line of lines) {
+    const [ tag, version ] = line.split(': ');
+    r[tag] = await parseVersion(version);
+  }
+  return r;
+};
+
+export const shouldTagLatest = (newVersion: Version, currentTags: NpmTags): boolean =>
+  pipe(
+    O.fromNullable(currentTags.latest),
+    O.fold(
+      () => true,
+      (latest) => {
+        // All full releases beat all prereleases
+        if (isPreRelease(latest) && !isPreRelease(newVersion)) {
+          return true;
+        } else if (isPreRelease(newVersion) && !isPreRelease(latest)) {
+          return false;
+        } else {
+          return isGte(compareVersions(newVersion, latest));
+        }
+      }
+    )
+  );

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -81,6 +81,11 @@ export const getNpmTags = async (cwd: string, packageName: string): Promise<NpmT
   return r;
 };
 
+export const shouldTagLatestNpm = async (newVersion: Version, cwd: string, packageName: string): Promise<boolean> => {
+  const tags = await getNpmTagsOrNone(cwd, packageName);
+  return shouldTagLatest(newVersion, tags);
+};
+
 export const shouldTagLatest = (newVersion: Version, currentTags: NpmTags): boolean =>
   pipe(
     O.fromNullable(currentTags.latest),

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -2,23 +2,41 @@ import { SimpleGit } from 'simple-git/promise';
 import * as Git from '../utils/Git';
 import { BranchState, isLatestReleaseBranch } from './BranchLogic';
 import { majorMinorVersionToString, Version } from './Version';
+import * as PreRelease from '../core/PreRelease';
 
-export const pickTags = async (branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>): Promise<string[]> => {
+export const pickTags = async (branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>): Promise<[string, ...string[]]> => {
 
-  const mainTag = branchName.replace(/[^\w.]+/g, '-');
+  const branchTag = branchName.replace(/[^\w.]+/g, '-');
 
-  if (branchState === BranchState.ReleaseCandidate) {
-    const vs = majorMinorVersionToString(version);
-    return [ `rc-${vs}` ];
+  const vs = majorMinorVersionToString(version);
 
-  } else if (branchState === BranchState.ReleaseReady) {
-    const isLatest = await isLatestReleaseBranch(branchName, await getBranches());
-    return isLatest ? [ mainTag, 'latest' ] : [ mainTag ];
+  const rcTagName = () => `${PreRelease.releaseCandidate}-${vs}`;
+
+  // Note: we tag releases as release-x.y. This seems unnecessary, as you can use package@x.y to refer to it.
+  // However, we need to pick at least one tag for each build, otherwise npm publish will tag builds as 'latest'.
+  // Adding this tag covers a few scenarios where we don't otherwise have a tag to add.
+
+  if (branchName === 'main') {
+    if (branchState === BranchState.ReleaseCandidate) {
+      return [ branchTag, rcTagName() ];
+
+    } else if (branchState === BranchState.ReleaseReady) {
+      // assume main is always latest minor version
+      return [ branchTag, 'latest', `release-${vs}` ];
+    }
 
   } else {
-    return [ mainTag ];
+    if (branchState === BranchState.ReleaseCandidate) {
+      // tagging a prerelease as release-x.y would be confusing
+      return [ rcTagName() ];
+
+    } else if (branchState === BranchState.ReleaseReady) {
+      const isLatest = await isLatestReleaseBranch(branchName, await getBranches());
+      return isLatest ? [ branchTag, 'latest' ] : [ branchTag ];
+    }
   }
+  return [ branchTag ];
 };
 
-export const pickTagsGit = async (branchName: string, branchState: BranchState, version: Version, git: SimpleGit): Promise<string[]> =>
+export const pickTagsGit = async (branchName: string, branchState: BranchState, version: Version, git: SimpleGit): Promise<[string, ...string[]]> =>
   pickTags(branchName, branchState, version, () => Git.remoteBranchNames(git));

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -64,7 +64,7 @@ export type NpmTags = Record<string, Version>;
 
 /**
  * If a package hasn't been published before, getNpmTags will fail. However, we need a list of tags for the first publish.
- * This function falls back to an empty list of tags if getNpmTags fails.
+ * This function falls back to an empty object of tags if getNpmTags fails.
  */
 export const getNpmTagsOrNone = (cwd: string, packageName: string): Promise<NpmTags> =>
   PromiseUtils.getOrElse(getNpmTags(cwd, packageName), {});

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -1,10 +1,12 @@
 import { SimpleGit } from 'simple-git/promise';
 import * as Git from '../utils/Git';
+import * as PreRelease from '../core/PreRelease';
 import { BranchState, isLatestReleaseBranch } from './BranchLogic';
 import { majorMinorVersionToString, Version } from './Version';
-import * as PreRelease from '../core/PreRelease';
 
-export const pickTags = async (branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>): Promise<[string, ...string[]]> => {
+export const pickTags = async (
+  branchName: string, branchState: BranchState, version: Version, getBranches: () => Promise<string[]>
+): Promise<[string, ...string[]]> => {
 
   const branchTag = branchName.replace(/[^\w.]+/g, '-');
 

--- a/src/main/ts/core/PreRelease.ts
+++ b/src/main/ts/core/PreRelease.ts
@@ -1,5 +1,4 @@
 export const releaseCandidate = 'rc';
-export const mainBranch = 'alpha';
 export const featureBranch = 'feature';
 export const hotfixBranch = 'hotfix';
 export const spikeBranch = 'spike';

--- a/src/main/ts/core/Version.ts
+++ b/src/main/ts/core/Version.ts
@@ -1,5 +1,4 @@
 import * as PromiseUtils from '../utils/PromiseUtils';
-import * as ArrayUtils from '../utils/ArrayUtils';
 import { Comparison, fromNumber } from '../utils/Comparison';
 
 export interface Version {
@@ -67,9 +66,6 @@ export const versionToString = (v: Version): string => {
 
 export const compareMajorMinorVersions = (a: MajorMinorVersion, b: MajorMinorVersion): Comparison =>
   fromNumber(a.major !== b.major ? a.major - b.major : a.minor - b.minor);
-
-export const sortMajorMinorVersions = (vs: MajorMinorVersion[]): MajorMinorVersion[] =>
-  ArrayUtils.sort(vs, compareMajorMinorVersions);
 
 export const isPreRelease = (v: Version): boolean =>
   v.preRelease !== undefined;

--- a/src/main/ts/utils/ArrayUtils.ts
+++ b/src/main/ts/utils/ArrayUtils.ts
@@ -1,9 +1,14 @@
 import * as O from 'fp-ts/Option';
+import * as Comparison from './Comparison';
 
 type Option<A> = O.Option<A>;
+type Comparison = Comparison.Comparison;
 
 export const sort = <T> (ts: T[], compareFn?: (a: T, b: T) => number): T[] =>
   [ ...ts ].sort(compareFn);
+
+export const sortWithComparison = <T> (ts: T[], compareFn: (a: T, b: T) => Comparison) =>
+  sort(ts, (a, b) => Comparison.toNumber(compareFn(a, b)));
 
 export const last = <T> (ts: T[]): Option<T> =>
   ts.length === 0 ? O.none : O.some(ts[ts.length - 1]);

--- a/src/main/ts/utils/ArrayUtils.ts
+++ b/src/main/ts/utils/ArrayUtils.ts
@@ -1,12 +1,2 @@
-import * as O from 'fp-ts/Option';
-
-type Option<A> = O.Option<A>;
-
 export const sort = <T> (ts: T[], compareFn?: (a: T, b: T) => number): T[] =>
   [ ...ts ].sort(compareFn);
-
-export const last = <T> (ts: T[]): Option<T> =>
-  ts.length === 0 ? O.none : O.some(ts[ts.length - 1]);
-
-export const greatest = <T> (ts: T[], compareFn?: (a: T, b: T) => number): Option<T> =>
-  last(sort(ts, compareFn));

--- a/src/main/ts/utils/ArrayUtils.ts
+++ b/src/main/ts/utils/ArrayUtils.ts
@@ -1,14 +1,9 @@
 import * as O from 'fp-ts/Option';
-import * as Comparison from './Comparison';
 
 type Option<A> = O.Option<A>;
-type Comparison = Comparison.Comparison;
 
 export const sort = <T> (ts: T[], compareFn?: (a: T, b: T) => number): T[] =>
   [ ...ts ].sort(compareFn);
-
-export const sortWithComparison = <T> (ts: T[], compareFn: (a: T, b: T) => Comparison) =>
-  sort(ts, (a, b) => Comparison.toNumber(compareFn(a, b)));
 
 export const last = <T> (ts: T[]): Option<T> =>
   ts.length === 0 ? O.none : O.some(ts[ts.length - 1]);

--- a/src/main/ts/utils/Comparison.ts
+++ b/src/main/ts/utils/Comparison.ts
@@ -4,27 +4,6 @@ export const enum Comparison {
   GT = 1
 }
 
-export const toNumber = (c: Comparison): number => {
-  switch (c) {
-    case Comparison.LT:
-      return -1;
-    case Comparison.EQ:
-      return 0;
-    case Comparison.GT:
-      return 1;
-  }
-};
-
-export const fromNumber = (n: number): Comparison => {
-  if (n < 0) {
-    return Comparison.LT;
-  } else if (n === 0) {
-    return Comparison.EQ;
-  } else {
-    return Comparison.GT;
-  }
-};
-
 export const compareNative = <A> (a: A, b: A): Comparison => {
   if (a < b) {
     return Comparison.LT;
@@ -34,6 +13,12 @@ export const compareNative = <A> (a: A, b: A): Comparison => {
     return Comparison.GT;
   }
 };
+
+export const chain = (c1: Comparison, c2: Comparison): Comparison =>
+  c1 !== Comparison.EQ ? c1 : c2;
+
+export const chainN = (...cs: Comparison[]): Comparison =>
+  cs.reduce(chain, Comparison.EQ);
 
 export const isGte = (c: Comparison): boolean =>
   c !== Comparison.LT;

--- a/src/main/ts/utils/Comparison.ts
+++ b/src/main/ts/utils/Comparison.ts
@@ -1,0 +1,48 @@
+export const enum Comparison {
+  LT = -1,
+  EQ = 0,
+  GT = 1
+}
+
+export const toNumber = (c: Comparison): number => {
+  switch (c) {
+    case Comparison.LT:
+      return -1;
+    case Comparison.EQ:
+      return 0;
+    case Comparison.GT:
+      return 1;
+  }
+};
+
+export const fromNumber = (n: number): Comparison => {
+  if (n < 0) {
+    return Comparison.LT;
+  } else if (n === 0) {
+    return Comparison.EQ;
+  } else {
+    return Comparison.GT;
+  }
+};
+
+export const compareNative = <A> (a: A, b: A): Comparison => {
+  if (a < b) {
+    return Comparison.LT;
+  } else if (a === b) {
+    return Comparison.EQ;
+  } else {
+    return Comparison.GT;
+  }
+};
+
+export const drill = (a: Comparison, b: () => Comparison): Comparison =>
+  a === Comparison.EQ ? b() : a;
+
+export const isGte = (c: Comparison): boolean =>
+  c !== Comparison.LT;
+
+export const isLte = (c: Comparison): boolean =>
+  c !== Comparison.GT;
+
+export const isNotEqual = (c: Comparison): boolean =>
+  c !== Comparison.EQ;

--- a/src/main/ts/utils/Comparison.ts
+++ b/src/main/ts/utils/Comparison.ts
@@ -35,9 +35,6 @@ export const compareNative = <A> (a: A, b: A): Comparison => {
   }
 };
 
-export const drill = (a: Comparison, b: () => Comparison): Comparison =>
-  a === Comparison.EQ ? b() : a;
-
 export const isGte = (c: Comparison): boolean =>
   c !== Comparison.LT;
 

--- a/src/main/ts/utils/ObjUtils.ts
+++ b/src/main/ts/utils/ObjUtils.ts
@@ -7,3 +7,11 @@ export const hasKey = <T>(o: T, k: keyof T): boolean =>
 
 export const lookup = <T>(o: T, k: keyof T): Option<T[keyof T]> =>
   hasKey(o, k) ? O.some(o[k]) : O.none;
+
+export const map = <A, B>(o: Record<string, A>, f: (a: A) => B): Record<string, B> => {
+  const r: Record<string, B> = {};
+  for (const k of Object.keys(o)) {
+    r[k] = f(o[k]);
+  }
+  return r;
+};

--- a/src/main/ts/utils/PromiseUtils.ts
+++ b/src/main/ts/utils/PromiseUtils.ts
@@ -31,6 +31,9 @@ const errorify = (error?: unknown): unknown =>
 export const tryPromise = <A> (p: Promise<A>): Promise<Either<unknown, A>> =>
   p.then(E.right, E.left);
 
+export const getOrElse = <A> (p: Promise<A>, other: A): Promise<A> =>
+  p.then((x) => x, () => other);
+
 export const parMap = <A, B> (input: A[], p: (a: A) => Promise<B>): Promise<B[]> =>
   Promise.all(input.map(p));
 

--- a/src/test/ts/args/ParserTest.ts
+++ b/src/test/ts/args/ParserTest.ts
@@ -14,6 +14,7 @@ describe('Parser', () => {
     it('fails with no args', async () => {
       await assert.isRejected(parseArgs([]));
     });
+
     it('succeeds for prepare command', async () => {
       await assert.becomes(
         parseArgs([ 'prepare' ]),
@@ -24,35 +25,55 @@ describe('Parser', () => {
         O.some(BeehiveArgs.prepareArgs(true, process.cwd(), O.none, O.none))
       );
     });
-    it('succeeds for release command', async () => {
+
+    it('succeeds for release command with major.minor arg', async () => {
       await fc.assert(fc.asyncProperty(fc.nat(100), fc.nat(100), async (major, minor) => {
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}` ]),
-          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, { major, minor }))
+          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
         );
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}`, '--dry-run' ]),
-          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, { major, minor }))
+          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
         );
       }));
     });
-    it('succeeds for advance command', async () => {
+
+    it('succeeds for release command with main arg', async () => {
+      await assert.becomes(
+        parseArgs([ 'release', 'main' ]),
+        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main'))
+      );
+    });
+
+    it('succeeds for advance command with major.minor arg', async () => {
       await fc.assert(fc.asyncProperty(fc.nat(100), fc.nat(100), async (major, minor) => {
         await assert.becomes(
           parseArgs([ 'advance', `${major}.${minor}` ]),
-          O.some(BeehiveArgs.advanceArgs(false, process.cwd(), O.none, O.none, { major, minor }))
+          O.some(BeehiveArgs.advanceArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
         );
         await assert.becomes(
           parseArgs([ 'advance', `${major}.${minor}`, '--dry-run' ]),
-          O.some(BeehiveArgs.advanceArgs(true, process.cwd(), O.none, O.none, { major, minor }))
+          O.some(BeehiveArgs.advanceArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
         );
       }));
     });
-    it('succeeds for advance command', async () => {
+
+    it('succeeds for advance command with main arg', async () => {
+      await assert.becomes(
+        parseArgs([ 'advance', 'main' ]),
+        O.some(BeehiveArgs.advanceArgs(false, process.cwd(), O.none, O.none, 'main'))
+      );
+    });
+
+    it('succeeds for stamp command', async () => {
       await assert.becomes(
         parseArgs([ 'stamp' ]),
         O.some(BeehiveArgs.stampArgs(false, process.cwd()))
       );
+    });
+
+    it('succeeds for stamp command with dry-run', async () => {
       await assert.becomes(
         parseArgs([ 'stamp', '--dry-run' ]),
         O.some(BeehiveArgs.stampArgs(true, process.cwd()))

--- a/src/test/ts/commands/AdvanceTest.ts
+++ b/src/test/ts/commands/AdvanceTest.ts
@@ -2,9 +2,10 @@ import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as Advance from '../../../main/ts/commands/Advance';
 import * as Version from '../../../main/ts/core/Version';
+import * as Git from '../../../main/ts/utils/Git';
+import { makeBranchWithPj, beehiveFlow, readPjVersionInDir } from './TestUtils';
 
 describe('Advance', () => {
-
   describe('updateVersion', () => {
     it('Updates versions', async () => {
       const check = async (input: string, expected: string) => {
@@ -13,6 +14,58 @@ describe('Advance', () => {
       await check('0.0.0', '0.0.1-rc');
       await check('1.0.0', '1.0.1-rc');
       await check('0.300.100', '0.300.101-rc');
+    });
+  });
+
+  describe('advance', () => {
+    const runScenario = async (branchName: string, version: string, arg: string) => {
+      const hub = await Git.initInTempFolder(true);
+      const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-advance', version);
+      await beehiveFlow([ 'advance', arg, '--working-dir', dir ]);
+      await git.pull();
+      return dir;
+    };
+
+    it('advances main branch in release state', async () => {
+      const dir = await runScenario('main', '1.2.3', 'main');
+      await assert.becomes(readPjVersionInDir(dir), '1.2.4-rc');
+    });
+
+    it('advances feature branch in release state', async () => {
+      const dir = await runScenario('release/6.7', '6.7.0', '6.7');
+      await assert.becomes(readPjVersionInDir(dir), '6.7.1-rc');
+    });
+  });
+
+  describe('advance-ci', () => {
+    const runScenario = async (branchName: string, version: string) => {
+      const hub = await Git.initInTempFolder(true);
+      const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-advance', version);
+      await beehiveFlow([ 'advance-ci', '--working-dir', dir ]);
+      await git.pull();
+      return dir;
+    };
+
+    it('advances main branch in release state', async () => {
+      const dir = await runScenario('main', '1.2.3');
+      await assert.becomes(readPjVersionInDir(dir), '1.2.4-rc');
+    });
+
+    it('does nothing for main branch in rc state', async () => {
+      const dir = await runScenario('main', '1.2.3-rc');
+      await assert.becomes(readPjVersionInDir(dir), '1.2.3-rc');
+    });
+
+    it('advances feature branch in release state', async () => {
+      const dir = await runScenario('release/6.7', '6.7.0');
+      await assert.becomes(readPjVersionInDir(dir), '6.7.1-rc');
+    });
+
+    it('does nothing for feature branch in rc state', async () => {
+      const dir = await runScenario('release/6.7', '6.7.78-rc');
+      await assert.becomes(readPjVersionInDir(dir), '6.7.78-rc');
     });
   });
 });

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -27,7 +27,7 @@ describe('Lifecycle', () => {
     await Files.writeFile(path.join(dir, 'package.json'), `
     {
       "name": "@beehive-test/lifecycle-test",
-      "version": "0.1.0-alpha"
+      "version": "0.1.0-rc"
     }
     `);
 
@@ -42,7 +42,7 @@ describe('Lifecycle', () => {
 
     await beehiveFlow([ 'prepare', '--git-url', hub.dir ]);
     await git.pull();
-    await assertPjVersion('0.2.0-alpha');
+    await assertPjVersion('0.2.0-rc');
 
     await git.checkout('release/0.1');
     await assertPjVersion('0.1.0-rc');

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -5,18 +5,11 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as O from 'fp-ts/Option';
 import * as Git from '../../../main/ts/utils/Git';
 import * as Files from '../../../main/ts/utils/Files';
-import * as Parser from '../../../main/ts/args/Parser';
-import * as Dispatch from '../../../main/ts/args/Dispatch';
 import * as PackageJson from '../../../main/ts/core/PackageJson';
 import * as Version from '../../../main/ts/core/Version';
-import { eachAsync } from '../../../main/ts/utils/OptionUtils';
+import { beehiveFlow } from './TestUtils';
 
 const assert = chai.use(chaiAsPromised).assert;
-
-const beehiveFlow = async (args: string[]): Promise<void> => {
-  const a = await Parser.parseArgs(args);
-  await eachAsync(a, Dispatch.dispatch);
-};
 
 describe('Lifecycle', () => {
   it('cycles', async () => {

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -7,7 +7,7 @@ import * as getPort from 'get-port';
 import * as Files from '../../../main/ts/utils/Files';
 import * as Git from '../../../main/ts/utils/Git';
 import * as PackageJson from '../../../main/ts/core/PackageJson';
-import { beehiveFlow, getNpmTags, makeBranchWithPj, readPjVersion, writeNpmrc } from './TestUtils';
+import { beehiveFlow, makeBranchWithPj, readPjVersion, writeNpmrc, getNpmTags } from './TestUtils';
 
 const startVerdaccio = async () => {
   const configDir = await Files.tempFolder();
@@ -73,7 +73,7 @@ describe('Publish', () => {
     await stamp(dir);
     const stampedVersion = await readPjVersion(pjFile);
     await publish(dryRun, dir);
-    const npmTags = getNpmTags(dir, packageName);
+    const npmTags = await getNpmTags(dir, packageName);
     const gitTags = (await git.tags()).all.sort();
     return { stampedVersion, npmTags, dir, git, gitTags, packageName };
   };
@@ -83,7 +83,7 @@ describe('Publish', () => {
   it('publishes rc from main branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('main', '0.1.0-rc', false);
     assert.deepEqual(npmTags, {
-      'latest': '0.0.1-rc',
+      'latest': stampedVersion,
       'feature-dummy': '0.0.1-rc',
       'main': stampedVersion,
       'rc-0.1': stampedVersion
@@ -105,7 +105,7 @@ describe('Publish', () => {
   it('publishes rc from release branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('release/0.5', '0.5.6-rc', false);
     assert.deepEqual(npmTags, {
-      'latest': '0.0.1-rc',
+      'latest': stampedVersion,
       'feature-dummy': '0.0.1-rc',
       'rc-0.5': stampedVersion
     });

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -122,7 +122,7 @@ describe('Publish', () => {
     assert.deepEqual(gitTags, [ `@beehive-test/${packageName}@0.5.444` ]);
   }).timeout(TIMEOUT);
 
-  it('publishes from from feature branch', async () => {
+  it('publishes from feature branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('feature/blah', '0.5.444-frog', false);
     assert.deepEqual(npmTags, {
       'latest': '0.0.1-rc',
@@ -132,7 +132,7 @@ describe('Publish', () => {
     assert.deepEqual(gitTags, []);
   }).timeout(TIMEOUT);
 
-  it('publishes from from hotfix branch', async () => {
+  it('publishes from hotfix branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('hotfix/blah', '0.5.444-frog', false);
     assert.deepEqual(npmTags, {
       'latest': '0.0.1-rc',
@@ -142,7 +142,7 @@ describe('Publish', () => {
     assert.deepEqual(gitTags, []);
   }).timeout(TIMEOUT);
 
-  it('publishes from from spike branch', async () => {
+  it('publishes from spike branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('spike/blah', '0.5.11-frog', false);
     assert.deepEqual(npmTags, {
       'latest': '0.0.1-rc',

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -54,9 +54,9 @@ describe('Publish', () => {
 
   let scenario = 0;
 
-  async function stamp(dir: string) {
+  const stamp = async (dir: string) => {
     await beehiveFlow([ 'stamp', '--working-dir', dir ]);
-  }
+  };
 
   const runScenario = async (branchName: string, version: string, dryRun: boolean) => {
     scenario++;
@@ -83,9 +83,9 @@ describe('Publish', () => {
   it('publishes rc from main branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('main', '0.1.0-rc', false);
     assert.deepEqual(npmTags, {
-      latest: '0.0.1-rc',
+      'latest': '0.0.1-rc',
       'feature-dummy': '0.0.1-rc',
-      main: stampedVersion,
+      'main': stampedVersion,
       'rc-0.1': stampedVersion
     });
     assert.deepEqual(gitTags, []);
@@ -95,8 +95,8 @@ describe('Publish', () => {
     const { npmTags, gitTags, packageName } = await runScenario('main', '0.1.0', false);
     assert.deepEqual(npmTags, {
       'feature-dummy': '0.0.1-rc',
-      main: '0.1.0',
-      latest: '0.1.0',
+      'main': '0.1.0',
+      'latest': '0.1.0',
       'release-0.1': '0.1.0'
     });
     assert.deepEqual(gitTags, [ `@beehive-test/${packageName}@0.1.0` ]);
@@ -105,7 +105,7 @@ describe('Publish', () => {
   it('publishes rc from release branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('release/0.5', '0.5.6-rc', false);
     assert.deepEqual(npmTags, {
-      latest: '0.0.1-rc',
+      'latest': '0.0.1-rc',
       'feature-dummy': '0.0.1-rc',
       'rc-0.5': stampedVersion
     });
@@ -116,7 +116,7 @@ describe('Publish', () => {
     const { npmTags, gitTags, packageName } = await runScenario('release/0.5', '0.5.444', false);
     assert.deepEqual(npmTags, {
       'feature-dummy': '0.0.1-rc',
-      latest: '0.5.444',
+      'latest': '0.5.444',
       'release-0.5': '0.5.444'
     });
     assert.deepEqual(gitTags, [ `@beehive-test/${packageName}@0.5.444` ]);
@@ -125,9 +125,9 @@ describe('Publish', () => {
   it('publishes from from feature branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('feature/blah', '0.5.444-frog', false);
     assert.deepEqual(npmTags, {
-      latest: '0.0.1-rc',
+      'latest': '0.0.1-rc',
       'feature-dummy': '0.0.1-rc',
-      'feature-blah' : stampedVersion
+      'feature-blah': stampedVersion
     });
     assert.deepEqual(gitTags, []);
   }).timeout(TIMEOUT);
@@ -135,9 +135,9 @@ describe('Publish', () => {
   it('publishes from from hotfix branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('hotfix/blah', '0.5.444-frog', false);
     assert.deepEqual(npmTags, {
-      latest: '0.0.1-rc',
+      'latest': '0.0.1-rc',
       'feature-dummy': '0.0.1-rc',
-      'hotfix-blah' : stampedVersion
+      'hotfix-blah': stampedVersion
     });
     assert.deepEqual(gitTags, []);
   }).timeout(TIMEOUT);
@@ -145,9 +145,9 @@ describe('Publish', () => {
   it('publishes from from spike branch', async () => {
     const { stampedVersion, npmTags, gitTags } = await runScenario('spike/blah', '0.5.11-frog', false);
     assert.deepEqual(npmTags, {
-      latest: '0.0.1-rc',
+      'latest': '0.0.1-rc',
       'feature-dummy': '0.0.1-rc',
-      'spike-blah' : stampedVersion
+      'spike-blah': stampedVersion
     });
     assert.deepEqual(gitTags, []);
   }).timeout(TIMEOUT);

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -1,11 +1,11 @@
 import * as cp from 'child_process';
 import * as path from 'path';
-import * as fs from 'fs';
+// import * as fs from 'fs';
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as getPort from 'get-port';
-import { ResetMode } from 'simple-git';
-import { SimpleGit } from 'simple-git/promise';
+// import { ResetMode } from 'simple-git';
+// import { SimpleGit } from 'simple-git/promise';
 import * as Files from '../../../main/ts/utils/Files';
 import * as Git from '../../../main/ts/utils/Git';
 import * as Parser from '../../../main/ts/args/Parser';
@@ -20,8 +20,8 @@ const beehiveFlow = async (args: string[]): Promise<void> => {
   }
 };
 
-const getTags = (cwd: string): Record<string, string> => {
-  const output = cp.execSync('npm dist-tag ls @beehive-test/beehive-test', { cwd }).toString();
+const getTags = (cwd: string, packageName: string): Record<string, string> => {
+  const output = cp.execSync(`npm dist-tag ls @beehive-test/${packageName}`, { cwd }).toString();
   const lines = output.split('\n').filter((x) => x.length > 0);
   const r: Record<string, string> = {};
 
@@ -67,9 +67,9 @@ const publish = async (dryRun: boolean, dir: string): Promise<void> => {
   await beehiveFlow([ 'publish', '--working-dir', dir, ...dryRunArgs ]);
 };
 
-const assertGitTags = async (expectedTags: string[], git: SimpleGit): Promise<void> => {
-  assert.deepEqual((await git.tags()).all.sort(), expectedTags.sort());
-};
+// const assertGitTags = async (expectedTags: string[], git: SimpleGit): Promise<void> => {
+//   assert.deepEqual((await git.tags()).all.sort(), expectedTags.sort());
+// };
 
 describe('Publish', () => {
 
@@ -86,145 +86,197 @@ describe('Publish', () => {
     verdaccio.kill();
   });
 
-  it('publishes', async () => {
+  async function stamp(dir: string) {
+    await beehiveFlow([ 'stamp', '--working-dir', dir ]);
+  }
 
+  const readPjVersion = async (pjFile: string): Promise<string> => {
+    const pj = await PackageJson.parsePackageJsonFile(pjFile);
+    const v = pj.version;
+    if (v._tag !== 'Some') {
+      throw new Error('Version should be some');
+    }
+    return versionToString(v.value);
+  };
+
+  const runScenario = async (branchName: string, packageName: string, version: string, dryRun: boolean) => {
     const hub = await Git.initInTempFolder(true);
-
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-    await Git.checkoutNewBranch(git, 'main');
-
+    await Git.checkoutNewBranch(git, branchName);
     const npmrcFile = await writeNpmrc(address, dir);
-
     const pjFile = path.join(dir, 'package.json');
-
-    const writePj = async (version: string): Promise<void> => {
-      const pjContents = `
+    const pjContents = `
       {
-        "name": "@beehive-test/beehive-test",
+        "name": "@beehive-test/${packageName}",
         "version": "${version}",
         "publishConfig": {
           "@beehive-test:registry": "${address}"
         }
       }`;
-      await Files.writeFile(pjFile, pjContents);
-      await git.add([ npmrcFile, pjFile ]);
-      await git.commit('commit');
-      await Git.push(git);
-    };
-
-    const go = async (version: string, dryRun: boolean) => {
-      await writePj(version);
-      await publish(dryRun, dir);
-      return getTags(dir);
-    };
-
-    const featureBranch = 'feature/TINY-BLAH';
-    const featureBranchTag = 'feature-TINY-BLAH';
-
-    // PUBLISH 0 - main branch
-    // NOTE: first publish always ends up tagged latest
-    await writePj('0.1.0-alpha');
-    await beehiveFlow([ 'stamp', '--working-dir', dir ]);
-    const pj = await PackageJson.parsePackageJsonFileInFolder(dir);
-    const v = pj.version;
-    if (v._tag !== 'Some') {
-      throw new Error('Version should be some');
-    }
-    await publish(false, dir);
-    const tags0 = getTags(dir);
-    const ver0 = versionToString(v.value);
-    assert.deepEqual(tags0, { latest: ver0, main: ver0 });
-
-    await git.reset(ResetMode.HARD);
-
-    // PUBLISH 1 - feature branch
-    await git.pull();
-    await Git.checkoutNewBranch(git, featureBranch);
-    const tags1 = await go('0.1.0-alpha', false);
-    assert.deepEqual(tags1, { latest: ver0, main: ver0, [ featureBranchTag ]: '0.1.0-alpha' });
-
-    // PUBLISH 2 - feature branch
-    const tags2 = await go('0.2.0-alpha', false);
-    assert.deepEqual(tags2, { latest: ver0, main: ver0, [ featureBranchTag ]: '0.2.0-alpha' });
-
-    // PUBLISH 3 - dry-run
-    const tags3 = await go('0.3.0-alpha', true);
-    assert.deepEqual(tags3, { latest: ver0, main: ver0, [ featureBranchTag ]: '0.2.0-alpha' });
-
-    // PUBLISH 4 - release state
-    await Git.checkoutNewBranch(git, 'release/0.1');
-    const tags4 = await go('0.1.0', false);
-    assert.deepEqual(tags4, { 'latest': '0.1.0', 'main': ver0, [ featureBranchTag ]: '0.2.0-alpha', 'release-0.1': '0.1.0' });
-    await assertGitTags([ '@beehive-test/beehive-test@0.1.0' ], git);
-
-    // PUBLISH 5 - next release
-    await Git.checkoutNewBranch(git, 'release/0.2');
-    const tags5 = await go('0.2.0', false);
-    assert.deepEqual(tags5, { 'latest': '0.2.0', 'main': ver0, [ featureBranchTag ]: '0.2.0-alpha', 'release-0.1': '0.1.0', 'release-0.2': '0.2.0' });
-    await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0' ], git);
-
-    // PUBLISH 6 - re-release 0.1
-    await git.checkout('release/0.1');
-    const tags6 = await go('0.1.1', false);
-    assert.deepEqual(tags6, { 'latest': '0.2.0', 'main': ver0, [ featureBranchTag ]: '0.2.0-alpha', 'release-0.1': '0.1.1', 'release-0.2': '0.2.0' });
-    await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0', '@beehive-test/beehive-test@0.1.1' ], git);
-  }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
-
-  it('publishes from dist-dir', async () => {
-
-    const hub = await Git.initInTempFolder(true);
-
-    const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-
-    await Git.checkoutNewBranch(git, 'release/1.1');
-
-    const npmrcFile = await writeNpmrc(address, dir);
-
-    const pjFile = path.join(dir, 'package.json');
-
-    const pjContents = `
-      {
-        "name": "@beehive-test/beehive-test-dist-dir",
-        "version": "1.1.3",
-        "publishConfig": {
-          "@beehive-test:registry": "${address}"
-        },
-        "dependencies": {
-          "@tinymce/tinymce-react": "3.8.4"
-        }
-      }`;
     await Files.writeFile(pjFile, pjContents);
-
-    // sanity check that reading the dependencies works
-    const readPj = await PackageJson.parsePackageJsonFile(pjFile);
-    assert.deepEqual(readPj.other.dependencies, { '@tinymce/tinymce-react': '3.8.4' });
-
-    fs.mkdirSync(path.join(dir, 'mydist'));
-
-    const pjDistFile = path.join(dir, 'mydist', 'package.json');
-    const pjDistContents = `
-      {
-        "name": "@beehive-test/beehive-test-dist-dir",
-        "version": "1.1.3",
-        "publishConfig": {
-          "@beehive-test:registry": "${address}"
-        },
-        "dependencies": {}
-      }`;
-    await Files.writeFile(pjDistFile, pjDistContents);
-
-    await git.add([ npmrcFile, pjFile, pjDistFile ]);
-    await git.commit('blah');
+    await git.add([ npmrcFile, pjFile ]);
+    await git.commit('commit');
     await Git.push(git);
+    await stamp(dir);
+    const stampedVersion = await readPjVersion(pjFile);
+    await publish(dryRun, dir);
+    const tags = getTags(dir, packageName);
+    return { stampedVersion, tags, dir, git };
+  };
 
-    await beehiveFlow([ 'publish', '--working-dir', dir, '--dist-dir', 'mydist' ]);
+  const TIMEOUT = 120000;
 
-    const downstream = await Files.tempFolder();
-    await writeNpmrc(address, downstream);
-    cp.execSync('npm add @beehive-test/beehive-test-dist-dir@1.1.3', { cwd: downstream });
-
-    const depPj = await PackageJson.parsePackageJsonFileInFolder(path.join(downstream, 'node_modules', '@beehive-test', 'beehive-test-dist-dir'));
-
-    assert.deepEqual(depPj.other.dependencies, {});
-  }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
+  it('publishes rc from main branch', async () => {
+    const { stampedVersion, tags } = await runScenario('main', 'rc-main', '0.1.0', false);
+    assert.deepEqual(tags, {
+      main: stampedVersion,
+      latest: stampedVersion,
+      'release-0.1': stampedVersion
+    });
+  }).timeout(TIMEOUT);
+  //
+  // it('publishes', async () => {
+  //
+  //   const hub = await Git.initInTempFolder(true);
+  //
+  //   const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+  //   await Git.checkoutNewBranch(git, 'main');
+  //
+  //   const npmrcFile = await writeNpmrc(address, dir);
+  //
+  //   const pjFile = path.join(dir, 'package.json');
+  //
+  //   const writePj = async (version: string): Promise<void> => {
+  //     const pjContents = `
+  //     {
+  //       "name": "@beehive-test/beehive-test",
+  //       "version": "${version}",
+  //       "publishConfig": {
+  //         "@beehive-test:registry": "${address}"
+  //       }
+  //     }`;
+  //     await Files.writeFile(pjFile, pjContents);
+  //     await git.add([ npmrcFile, pjFile ]);
+  //     await git.commit('commit');
+  //     await Git.push(git);
+  //
+  //
+  //   };
+  //
+  //   const go = async (originalVersion: string, dryRun: boolean) => {
+  //     await git.reset(ResetMode.HARD);
+  //
+  //     await writePj(originalVersion);
+  //     await stamp(dir);
+  //     await publish(dryRun, dir);
+  //     const tags = getTags(dir);
+  //     const version = await readPjVersion();
+  //     return { tags, version };
+  //   };
+  //
+  //   const featureBranch = 'feature/TINY-BLAH';
+  //   const featureBranchTag: string = 'feature-TINY-BLAH';
+  //
+  //   // PUBLISH 1 - main branch
+  //   // NOTE: first publish always ends up tagged latest
+  //   await writePj('0.1.0-rc');
+  //   await stamp(dir);
+  //   const ver0 = await readPjVersion();
+  //   await publish(false, dir);
+  //   const tags0 = getTags(dir);
+  //
+  //   assert.deepEqual(tags0, { latest: ver0, main: ver0, 'rc-0.1': ver0 });
+  //
+  //   await git.reset(ResetMode.HARD);
+  //
+  //   // PUBLISH 2 - feature branch
+  //   await git.pull();
+  //   await Git.checkoutNewBranch(git, featureBranch);
+  //   const publish2 = await go('0.1.0-rc', false);
+  //   assert.deepEqual(publish2.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish2.version });
+  //
+  //   // PUBLISH 3 - feature branch
+  //   const publish3 = await go('0.2.0-alpha', false);
+  //   assert.deepEqual(publish3.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version });
+  //
+  //   // PUBLISH 4 - dry-run
+  //   const publish4 = await go('0.3.0-alpha', true);
+  //   assert.deepEqual(publish4.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version });
+  //
+  //   // PUBLISH 5 - release state
+  //   await Git.checkoutNewBranch(git, 'release/0.1');
+  //   const publish5 = await go('0.1.0', false);
+  //   assert.deepEqual(publish5.tags, { 'latest': '0.1.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.0' });
+  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0' ], git);
+  //
+  //   // PUBLISH 6 - next release
+  //   await Git.checkoutNewBranch(git, 'release/0.2');
+  //   const publish6 = await go('0.2.0', false);
+  //   assert.deepEqual(publish6.tags, { 'latest': '0.2.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.0', 'release-0.2': '0.2.0' });
+  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0' ], git);
+  //
+  //   // PUBLISH 7 - re-release 0.1
+  //   await git.checkout('release/0.1');
+  //   const publish7 = await go('0.1.1', false);
+  //   assert.deepEqual(publish7.tags, { 'latest': '0.2.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.1', 'release-0.2': '0.2.0' });
+  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0', '@beehive-test/beehive-test@0.1.1' ], git);
+  // }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
+  //
+  // it('publishes from dist-dir', async () => {
+  //
+  //   const hub = await Git.initInTempFolder(true);
+  //
+  //   const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+  //
+  //   await Git.checkoutNewBranch(git, 'release/1.1');
+  //
+  //   const npmrcFile = await writeNpmrc(address, dir);
+  //
+  //   const pjFile = path.join(dir, 'package.json');
+  //
+  //   const pjContents = `
+  //     {
+  //       "name": "@beehive-test/beehive-test-dist-dir",
+  //       "version": "1.1.3",
+  //       "publishConfig": {
+  //         "@beehive-test:registry": "${address}"
+  //       },
+  //       "dependencies": {
+  //         "@tinymce/tinymce-react": "3.8.4"
+  //       }
+  //     }`;
+  //   await Files.writeFile(pjFile, pjContents);
+  //
+  //   // sanity check that reading the dependencies works
+  //   const readPj = await PackageJson.parsePackageJsonFile(pjFile);
+  //   assert.deepEqual(readPj.other.dependencies, { '@tinymce/tinymce-react': '3.8.4' });
+  //
+  //   fs.mkdirSync(path.join(dir, 'mydist'));
+  //
+  //   const pjDistFile = path.join(dir, 'mydist', 'package.json');
+  //   const pjDistContents = `
+  //     {
+  //       "name": "@beehive-test/beehive-test-dist-dir",
+  //       "version": "1.1.3",
+  //       "publishConfig": {
+  //         "@beehive-test:registry": "${address}"
+  //       },
+  //       "dependencies": {}
+  //     }`;
+  //   await Files.writeFile(pjDistFile, pjDistContents);
+  //
+  //   await git.add([ npmrcFile, pjFile, pjDistFile ]);
+  //   await git.commit('blah');
+  //   await Git.push(git);
+  //
+  //   await beehiveFlow([ 'publish', '--working-dir', dir, '--dist-dir', 'mydist' ]);
+  //
+  //   const downstream = await Files.tempFolder();
+  //   await writeNpmrc(address, downstream);
+  //   cp.execSync('npm add @beehive-test/beehive-test-dist-dir@1.1.3', { cwd: downstream });
+  //
+  //   const depPj = await PackageJson.parsePackageJsonFileInFolder(path.join(downstream, 'node_modules', '@beehive-test', 'beehive-test-dist-dir'));
+  //
+  //   assert.deepEqual(depPj.other.dependencies, {});
+  // }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
 });

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -1,11 +1,10 @@
 import * as cp from 'child_process';
 import * as path from 'path';
-// import * as fs from 'fs';
+import * as fs from 'fs';
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as getPort from 'get-port';
-// import { ResetMode } from 'simple-git';
-// import { SimpleGit } from 'simple-git/promise';
+import { SimpleGit } from 'simple-git/promise';
 import * as Files from '../../../main/ts/utils/Files';
 import * as Git from '../../../main/ts/utils/Git';
 import * as Parser from '../../../main/ts/args/Parser';
@@ -71,6 +70,25 @@ const publish = async (dryRun: boolean, dir: string): Promise<void> => {
 //   assert.deepEqual((await git.tags()).all.sort(), expectedTags.sort());
 // };
 
+const makeBranchWithPj = async (git: SimpleGit, branchName: string, address: string, dir: string, packageName: string, version: string) => {
+  await Git.checkoutNewBranch(git, branchName);
+  const npmrcFile = await writeNpmrc(address, dir);
+  const pjFile = path.join(dir, 'package.json');
+  const pjContents = `
+      {
+        "name": "@beehive-test/${packageName}",
+        "version": "${version}",
+        "publishConfig": {
+          "@beehive-test:registry": "${address}"
+        }
+      }`;
+  await Files.writeFile(pjFile, pjContents);
+  await git.add([ npmrcFile, pjFile ]);
+  await git.commit('commit');
+  await Git.push(git);
+  return pjFile;
+};
+
 describe('Publish', () => {
 
   let verdaccio: cp.ChildProcess;
@@ -86,6 +104,8 @@ describe('Publish', () => {
     verdaccio.kill();
   });
 
+  let scenario = 0;
+
   async function stamp(dir: string) {
     await beehiveFlow([ 'stamp', '--working-dir', dir ]);
   }
@@ -99,24 +119,18 @@ describe('Publish', () => {
     return versionToString(v.value);
   };
 
-  const runScenario = async (branchName: string, packageName: string, version: string, dryRun: boolean) => {
+  const runScenario = async (branchName: string, version: string, dryRun: boolean) => {
+    scenario++;
+    const packageName = `scenario-${scenario}`;
     const hub = await Git.initInTempFolder(true);
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-    await Git.checkoutNewBranch(git, branchName);
-    const npmrcFile = await writeNpmrc(address, dir);
-    const pjFile = path.join(dir, 'package.json');
-    const pjContents = `
-      {
-        "name": "@beehive-test/${packageName}",
-        "version": "${version}",
-        "publishConfig": {
-          "@beehive-test:registry": "${address}"
-        }
-      }`;
-    await Files.writeFile(pjFile, pjContents);
-    await git.add([ npmrcFile, pjFile ]);
-    await git.commit('commit');
-    await Git.push(git);
+
+    // publish a dummy version, so we have something as "latest"
+    await makeBranchWithPj(git, 'feature/dummy', address, dir, packageName, '0.0.1-rc');
+    await publish(dryRun, dir);
+
+    // publish the version we care about
+    const pjFile = await makeBranchWithPj(git, branchName, address, dir, packageName, version);
     await stamp(dir);
     const stampedVersion = await readPjVersion(pjFile);
     await publish(dryRun, dir);
@@ -127,156 +141,125 @@ describe('Publish', () => {
   const TIMEOUT = 120000;
 
   it('publishes rc from main branch', async () => {
-    const { stampedVersion, tags } = await runScenario('main', 'rc-main', '0.1.0', false);
+    const { stampedVersion, tags } = await runScenario('main', '0.1.0-rc', false);
     assert.deepEqual(tags, {
+      latest: '0.0.1-rc',
+      'feature-dummy': '0.0.1-rc',
       main: stampedVersion,
-      latest: stampedVersion,
-      'release-0.1': stampedVersion
+      'rc-0.1': stampedVersion
     });
   }).timeout(TIMEOUT);
-  //
-  // it('publishes', async () => {
-  //
-  //   const hub = await Git.initInTempFolder(true);
-  //
-  //   const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-  //   await Git.checkoutNewBranch(git, 'main');
-  //
-  //   const npmrcFile = await writeNpmrc(address, dir);
-  //
-  //   const pjFile = path.join(dir, 'package.json');
-  //
-  //   const writePj = async (version: string): Promise<void> => {
-  //     const pjContents = `
-  //     {
-  //       "name": "@beehive-test/beehive-test",
-  //       "version": "${version}",
-  //       "publishConfig": {
-  //         "@beehive-test:registry": "${address}"
-  //       }
-  //     }`;
-  //     await Files.writeFile(pjFile, pjContents);
-  //     await git.add([ npmrcFile, pjFile ]);
-  //     await git.commit('commit');
-  //     await Git.push(git);
-  //
-  //
-  //   };
-  //
-  //   const go = async (originalVersion: string, dryRun: boolean) => {
-  //     await git.reset(ResetMode.HARD);
-  //
-  //     await writePj(originalVersion);
-  //     await stamp(dir);
-  //     await publish(dryRun, dir);
-  //     const tags = getTags(dir);
-  //     const version = await readPjVersion();
-  //     return { tags, version };
-  //   };
-  //
-  //   const featureBranch = 'feature/TINY-BLAH';
-  //   const featureBranchTag: string = 'feature-TINY-BLAH';
-  //
-  //   // PUBLISH 1 - main branch
-  //   // NOTE: first publish always ends up tagged latest
-  //   await writePj('0.1.0-rc');
-  //   await stamp(dir);
-  //   const ver0 = await readPjVersion();
-  //   await publish(false, dir);
-  //   const tags0 = getTags(dir);
-  //
-  //   assert.deepEqual(tags0, { latest: ver0, main: ver0, 'rc-0.1': ver0 });
-  //
-  //   await git.reset(ResetMode.HARD);
-  //
-  //   // PUBLISH 2 - feature branch
-  //   await git.pull();
-  //   await Git.checkoutNewBranch(git, featureBranch);
-  //   const publish2 = await go('0.1.0-rc', false);
-  //   assert.deepEqual(publish2.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish2.version });
-  //
-  //   // PUBLISH 3 - feature branch
-  //   const publish3 = await go('0.2.0-alpha', false);
-  //   assert.deepEqual(publish3.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version });
-  //
-  //   // PUBLISH 4 - dry-run
-  //   const publish4 = await go('0.3.0-alpha', true);
-  //   assert.deepEqual(publish4.tags, { latest: ver0, main: ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version });
-  //
-  //   // PUBLISH 5 - release state
-  //   await Git.checkoutNewBranch(git, 'release/0.1');
-  //   const publish5 = await go('0.1.0', false);
-  //   assert.deepEqual(publish5.tags, { 'latest': '0.1.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.0' });
-  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0' ], git);
-  //
-  //   // PUBLISH 6 - next release
-  //   await Git.checkoutNewBranch(git, 'release/0.2');
-  //   const publish6 = await go('0.2.0', false);
-  //   assert.deepEqual(publish6.tags, { 'latest': '0.2.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.0', 'release-0.2': '0.2.0' });
-  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0' ], git);
-  //
-  //   // PUBLISH 7 - re-release 0.1
-  //   await git.checkout('release/0.1');
-  //   const publish7 = await go('0.1.1', false);
-  //   assert.deepEqual(publish7.tags, { 'latest': '0.2.0', 'main': ver0, 'rc-0.1': ver0, [ featureBranchTag ]: publish3.version, 'release-0.1': '0.1.1', 'release-0.2': '0.2.0' });
-  //   await assertGitTags([ '@beehive-test/beehive-test@0.1.0', '@beehive-test/beehive-test@0.2.0', '@beehive-test/beehive-test@0.1.1' ], git);
-  // }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
-  //
-  // it('publishes from dist-dir', async () => {
-  //
-  //   const hub = await Git.initInTempFolder(true);
-  //
-  //   const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-  //
-  //   await Git.checkoutNewBranch(git, 'release/1.1');
-  //
-  //   const npmrcFile = await writeNpmrc(address, dir);
-  //
-  //   const pjFile = path.join(dir, 'package.json');
-  //
-  //   const pjContents = `
-  //     {
-  //       "name": "@beehive-test/beehive-test-dist-dir",
-  //       "version": "1.1.3",
-  //       "publishConfig": {
-  //         "@beehive-test:registry": "${address}"
-  //       },
-  //       "dependencies": {
-  //         "@tinymce/tinymce-react": "3.8.4"
-  //       }
-  //     }`;
-  //   await Files.writeFile(pjFile, pjContents);
-  //
-  //   // sanity check that reading the dependencies works
-  //   const readPj = await PackageJson.parsePackageJsonFile(pjFile);
-  //   assert.deepEqual(readPj.other.dependencies, { '@tinymce/tinymce-react': '3.8.4' });
-  //
-  //   fs.mkdirSync(path.join(dir, 'mydist'));
-  //
-  //   const pjDistFile = path.join(dir, 'mydist', 'package.json');
-  //   const pjDistContents = `
-  //     {
-  //       "name": "@beehive-test/beehive-test-dist-dir",
-  //       "version": "1.1.3",
-  //       "publishConfig": {
-  //         "@beehive-test:registry": "${address}"
-  //       },
-  //       "dependencies": {}
-  //     }`;
-  //   await Files.writeFile(pjDistFile, pjDistContents);
-  //
-  //   await git.add([ npmrcFile, pjFile, pjDistFile ]);
-  //   await git.commit('blah');
-  //   await Git.push(git);
-  //
-  //   await beehiveFlow([ 'publish', '--working-dir', dir, '--dist-dir', 'mydist' ]);
-  //
-  //   const downstream = await Files.tempFolder();
-  //   await writeNpmrc(address, downstream);
-  //   cp.execSync('npm add @beehive-test/beehive-test-dist-dir@1.1.3', { cwd: downstream });
-  //
-  //   const depPj = await PackageJson.parsePackageJsonFileInFolder(path.join(downstream, 'node_modules', '@beehive-test', 'beehive-test-dist-dir'));
-  //
-  //   assert.deepEqual(depPj.other.dependencies, {});
-  // }).timeout(120000); // Verdaccio runs pretty slowly on the build servers;;
+
+  it('publishes release from main branch', async () => {
+    const { tags } = await runScenario('main', '0.1.0', false);
+    assert.deepEqual(tags, {
+      'feature-dummy': '0.0.1-rc',
+      main: '0.1.0',
+      latest: '0.1.0',
+      'release-0.1': '0.1.0'
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes rc from release branch', async () => {
+    const { stampedVersion, tags } = await runScenario('release/0.5', '0.5.6-rc', false);
+    assert.deepEqual(tags, {
+      latest: '0.0.1-rc',
+      'feature-dummy': '0.0.1-rc',
+      'rc-0.5': stampedVersion
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes release from release branch', async () => {
+    const { tags } = await runScenario('release/0.5', '0.5.444', false);
+    assert.deepEqual(tags, {
+      'feature-dummy': '0.0.1-rc',
+      latest: '0.5.444',
+      'release-0.5': '0.5.444'
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes from from feature branch', async () => {
+    const { stampedVersion, tags } = await runScenario('feature/blah', '0.5.444-frog', false);
+    assert.deepEqual(tags, {
+      latest: '0.0.1-rc',
+      'feature-dummy': '0.0.1-rc',
+      'feature-blah' : stampedVersion
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes from from hotfix branch', async () => {
+    const { stampedVersion, tags } = await runScenario('hotfix/blah', '0.5.444-frog', false);
+    assert.deepEqual(tags, {
+      latest: '0.0.1-rc',
+      'feature-dummy': '0.0.1-rc',
+      'hotfix-blah' : stampedVersion
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes from from spike branch', async () => {
+    const { stampedVersion, tags } = await runScenario('spike/blah', '0.5.11-frog', false);
+    assert.deepEqual(tags, {
+      latest: '0.0.1-rc',
+      'feature-dummy': '0.0.1-rc',
+      'spike-blah' : stampedVersion
+    });
+  }).timeout(TIMEOUT);
+
+  it('publishes from dist-dir', async () => {
+
+    const hub = await Git.initInTempFolder(true);
+
+    const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+
+    await Git.checkoutNewBranch(git, 'release/1.1');
+
+    const npmrcFile = await writeNpmrc(address, dir);
+
+    const pjFile = path.join(dir, 'package.json');
+
+    const pjContents = `
+      {
+        "name": "@beehive-test/beehive-test-dist-dir",
+        "version": "1.1.3",
+        "publishConfig": {
+          "@beehive-test:registry": "${address}"
+        },
+        "dependencies": {
+          "@tinymce/tinymce-react": "3.8.4"
+        }
+      }`;
+    await Files.writeFile(pjFile, pjContents);
+
+    // sanity check that reading the dependencies works
+    const readPj = await PackageJson.parsePackageJsonFile(pjFile);
+    assert.deepEqual(readPj.other.dependencies, { '@tinymce/tinymce-react': '3.8.4' });
+
+    fs.mkdirSync(path.join(dir, 'mydist'));
+
+    const pjDistFile = path.join(dir, 'mydist', 'package.json');
+    const pjDistContents = `
+      {
+        "name": "@beehive-test/beehive-test-dist-dir",
+        "version": "1.1.3",
+        "publishConfig": {
+          "@beehive-test:registry": "${address}"
+        },
+        "dependencies": {}
+      }`;
+    await Files.writeFile(pjDistFile, pjDistContents);
+
+    await git.add([ npmrcFile, pjFile, pjDistFile ]);
+    await git.commit('blah');
+    await Git.push(git);
+
+    await beehiveFlow([ 'publish', '--working-dir', dir, '--dist-dir', 'mydist' ]);
+
+    const downstream = await Files.tempFolder();
+    await writeNpmrc(address, downstream);
+    cp.execSync('npm add @beehive-test/beehive-test-dist-dir@1.1.3', { cwd: downstream });
+
+    const depPj = await PackageJson.parsePackageJsonFileInFolder(path.join(downstream, 'node_modules', '@beehive-test', 'beehive-test-dist-dir'));
+
+    assert.deepEqual(depPj.other.dependencies, {});
+  }).timeout(120000); // Verdaccio runs pretty slowly on the build servers
 });

--- a/src/test/ts/commands/ReleaseTest.ts
+++ b/src/test/ts/commands/ReleaseTest.ts
@@ -2,6 +2,8 @@ import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as Release from '../../../main/ts/commands/Release';
 import * as Version from '../../../main/ts/core/Version';
+import * as Git from '../../../main/ts/utils/Git';
+import { beehiveFlow, makeBranchWithPj, readPjVersionInDir } from './TestUtils';
 
 describe('Release', () => {
   describe('updateVersion', () => {
@@ -12,6 +14,27 @@ describe('Release', () => {
       await check('0.0.0-rc', '0.0.0');
       await check('1.0.0-rc', '1.0.0');
       await check('0.300.100-rc', '0.300.100');
+    });
+  });
+
+  describe('release', () => {
+    const runScenario = async (branchName: string, version: string, arg: string) => {
+      const hub = await Git.initInTempFolder(true);
+      const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-release', version);
+      await beehiveFlow([ 'release', arg, '--working-dir', dir ]);
+      await git.pull();
+      return dir;
+    };
+
+    it('releases rc version from main', async () => {
+      const dir = await runScenario('main', '0.0.1-rc', 'main');
+      await assert.becomes(readPjVersionInDir(dir), '0.0.1');
+    });
+
+    it('releases rc version from release branch', async () => {
+      const dir = await runScenario('release/88.1', '88.1.9-rc', '88.1');
+      await assert.becomes(readPjVersionInDir(dir), '88.1.9');
     });
   });
 });

--- a/src/test/ts/commands/StampTest.ts
+++ b/src/test/ts/commands/StampTest.ts
@@ -25,7 +25,7 @@ describe('Stamp', () => {
     const timeFormatted = '20201026065705074';
 
     it('makes a timestamped version on main branch', async () => {
-      const actual = Stamp.chooseNewVersion(BranchState.Main, await Version.parseVersion('1.2.0-alpha'), 'b0d52ad', timeMillis);
+      const actual = Stamp.chooseNewVersion(BranchState.ReleaseCandidate, await Version.parseVersion('1.2.0-alpha'), 'b0d52ad', timeMillis);
       assert.equal(Version.versionToString(actual), `1.2.0-alpha.${timeFormatted}.b0d52ad`);
     });
 

--- a/src/test/ts/commands/StatusTest.ts
+++ b/src/test/ts/commands/StatusTest.ts
@@ -33,12 +33,12 @@ const check = async (dir: string, expected: Object) => {
 };
 
 describe('Status', () => {
-  it('shows status for main', async () => {
+  it('shows status for main branch in preRelease state', async () => {
     const { dir, git } = await newGit();
-    await branchWithPj({ dir, git }, '0.1.0-alpha', 'main');
+    await branchWithPj({ dir, git }, '0.1.0-rc', 'main');
 
     await check(dir, {
-      branchState: 'main',
+      branchState: 'releaseCandidate',
       isLatestReleaseBranch: false,
       currentBranch: 'main',
       branchType: 'main',
@@ -46,13 +46,31 @@ describe('Status', () => {
         major: 0,
         minor: 1,
         patch: 0,
-        preRelease: 'alpha'
+        preRelease: 'rc'
       },
-      versionString: '0.1.0-alpha'
+      versionString: '0.1.0-rc'
     });
   });
 
-  it('shows status for rc', async () => {
+  it('shows status for main branch in releaseReady state', async () => {
+    const { dir, git } = await newGit();
+    await branchWithPj({ dir, git }, '0.7.0', 'main');
+
+    await check(dir, {
+      branchState: 'releaseReady',
+      isLatestReleaseBranch: false,
+      currentBranch: 'main',
+      branchType: 'main',
+      version: {
+        major: 0,
+        minor: 7,
+        patch: 0
+      },
+      versionString: '0.7.0'
+    });
+  });
+
+  it('shows status for release branch in preRelease state', async () => {
     const { dir, git } = await newGit();
     await branchWithPj({ dir, git }, '1.98.2-rc', 'release/1.98');
 
@@ -71,7 +89,7 @@ describe('Status', () => {
     });
   });
 
-  it('shows status for releaseReady', async () => {
+  it('shows status for release branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
     await branchWithPj({ dir, git }, '1.98.7', 'release/1.98');
 

--- a/src/test/ts/commands/StatusTest.ts
+++ b/src/test/ts/commands/StatusTest.ts
@@ -39,7 +39,7 @@ describe('Status', () => {
 
     await check(dir, {
       branchState: 'releaseCandidate',
-      isLatestReleaseBranch: false,
+      isLatest: true,
       currentBranch: 'main',
       branchType: 'main',
       version: {
@@ -50,7 +50,7 @@ describe('Status', () => {
       },
       versionString: '0.1.0-rc'
     });
-  });
+  }).timeout(20000);
 
   it('shows status for main branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
@@ -58,7 +58,7 @@ describe('Status', () => {
 
     await check(dir, {
       branchState: 'releaseReady',
-      isLatestReleaseBranch: false,
+      isLatest: true,
       currentBranch: 'main',
       branchType: 'main',
       version: {
@@ -68,7 +68,7 @@ describe('Status', () => {
       },
       versionString: '0.7.0'
     });
-  });
+  }).timeout(20000);
 
   it('shows status for release branch in preRelease state', async () => {
     const { dir, git } = await newGit();
@@ -76,7 +76,7 @@ describe('Status', () => {
 
     await check(dir, {
       branchState: 'releaseCandidate',
-      isLatestReleaseBranch: true,
+      isLatest: true,
       currentBranch: 'release/1.98',
       branchType: 'release',
       version: {
@@ -87,7 +87,7 @@ describe('Status', () => {
       },
       versionString: '1.98.2-rc'
     });
-  });
+  }).timeout(20000);
 
   it('shows status for release branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
@@ -95,7 +95,7 @@ describe('Status', () => {
 
     await check(dir, {
       branchState: 'releaseReady',
-      isLatestReleaseBranch: true,
+      isLatest: true,
       currentBranch: 'release/1.98',
       branchType: 'release',
       version: {
@@ -105,24 +105,7 @@ describe('Status', () => {
       },
       versionString: '1.98.7'
     });
-  });
+  }).timeout(20000);
 
-  it('shows status for releaseReady of "old" release', async () => {
-    const { dir, git } = await newGit();
-    await branchWithPj({ dir, git }, '41.98.7', 'release/41.98');
-    await branchWithPj({ dir, git }, '1.100.1', 'release/1.100');
-
-    await check(dir, {
-      branchState: 'releaseReady',
-      isLatestReleaseBranch: false,
-      currentBranch: 'release/1.100',
-      branchType: 'release',
-      version: {
-        major: 1,
-        minor: 100,
-        patch: 1
-      },
-      versionString: '1.100.1'
-    });
-  });
+  // TODO: Add test case where isLatest returns false. Will need to publish, or mock out listing tags.
 });

--- a/src/test/ts/commands/StatusTest.ts
+++ b/src/test/ts/commands/StatusTest.ts
@@ -107,5 +107,5 @@ describe('Status', () => {
     });
   }).timeout(20000);
 
-  // TODO: Add test case where isLatest returns false. Will need to publish, or mock out listing tags.
+  // TODO TINY-6924: Add test case where isLatest returns false. Will need to publish, or mock out listing tags.
 });

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -43,7 +43,7 @@ export const beehiveFlow = async (args: string[]): Promise<void> => {
   }
 };
 
-export const getTags = (cwd: string, packageName: string): Record<string, string> => {
+export const getNpmTags = (cwd: string, packageName: string): Record<string, string> => {
   const output = cp.execSync(`npm dist-tag ls @beehive-test/${packageName}`, { cwd }).toString();
   const lines = output.split('\n').filter((x) => x.length > 0);
   const r: Record<string, string> = {};

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -1,10 +1,10 @@
+import * as path from 'path';
+import * as cp from 'child_process';
 import { SimpleGit } from 'simple-git/promise';
 import * as Git from '../../../main/ts/utils/Git';
-import * as path from "path";
 import * as Files from '../../../main/ts/utils/Files';
 import * as Parser from '../../../main/ts/args/Parser';
 import * as Dispatch from '../../../main/ts/args/Dispatch';
-import * as cp from "child_process";
 import * as PackageJson from '../../../main/ts/core/PackageJson';
 import { versionToString } from '../../../main/ts/core/Version';
 

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -1,0 +1,68 @@
+import { SimpleGit } from 'simple-git/promise';
+import * as Git from '../../../main/ts/utils/Git';
+import * as path from "path";
+import * as Files from '../../../main/ts/utils/Files';
+import * as Parser from '../../../main/ts/args/Parser';
+import * as Dispatch from '../../../main/ts/args/Dispatch';
+import * as cp from "child_process";
+import * as PackageJson from '../../../main/ts/core/PackageJson';
+import { versionToString } from '../../../main/ts/core/Version';
+
+export const makeBranchWithPj = async (git: SimpleGit, branchName: string, address: string, dir: string, packageName: string, version: string) => {
+  await Git.checkoutNewBranch(git, branchName);
+  const npmrcFile = await writeNpmrc(address, dir);
+  const pjFile = path.join(dir, 'package.json');
+  const pjContents = `
+      {
+        "name": "@beehive-test/${packageName}",
+        "version": "${version}",
+        "publishConfig": {
+          "@beehive-test:registry": "${address}"
+        }
+      }`;
+  await Files.writeFile(pjFile, pjContents);
+  await git.add([ npmrcFile, pjFile ]);
+  await git.commit('commit');
+  await Git.push(git);
+  return pjFile;
+};
+
+export const writeNpmrc = async (address: string, dir: string): Promise<string> => {
+  const npmrc = `@beehive-test:registry=${address}`;
+  const npmrcFile = path.join(dir, '.npmrc');
+  await Files.writeFile(npmrcFile, npmrc);
+  return npmrcFile;
+};
+
+export const beehiveFlow = async (args: string[]): Promise<void> => {
+  const a = await Parser.parseArgs(args);
+  if (a._tag === 'Some') {
+    await Dispatch.dispatch(a.value);
+  } else {
+    throw new Error('Args parse failure');
+  }
+};
+
+export const getTags = (cwd: string, packageName: string): Record<string, string> => {
+  const output = cp.execSync(`npm dist-tag ls @beehive-test/${packageName}`, { cwd }).toString();
+  const lines = output.split('\n').filter((x) => x.length > 0);
+  const r: Record<string, string> = {};
+
+  for (const line of lines) {
+    const [ tag, version ] = line.split(': ');
+    r[tag] = version;
+  }
+  return r;
+};
+
+export const readPjVersion = async (pjFile: string): Promise<string> => {
+  const pj = await PackageJson.parsePackageJsonFile(pjFile);
+  const v = pj.version;
+  if (v._tag !== 'Some') {
+    throw new Error('Version should be some');
+  }
+  return versionToString(v.value);
+};
+
+export const readPjVersionInDir = async (dir: string): Promise<string> =>
+  readPjVersion(path.join(dir, 'package.json'));

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as cp from 'child_process';
 import { SimpleGit } from 'simple-git/promise';
 import * as Git from '../../../main/ts/utils/Git';
 import * as Files from '../../../main/ts/utils/Files';
@@ -7,6 +6,8 @@ import * as Parser from '../../../main/ts/args/Parser';
 import * as Dispatch from '../../../main/ts/args/Dispatch';
 import * as PackageJson from '../../../main/ts/core/PackageJson';
 import { versionToString } from '../../../main/ts/core/Version';
+import * as NpmTags from '../../../main/ts/core/NpmTags';
+import * as ObjUtils from '../../../main/ts/utils/ObjUtils';
 
 export const makeBranchWithPj = async (git: SimpleGit, branchName: string, address: string, dir: string, packageName: string, version: string) => {
   await Git.checkoutNewBranch(git, branchName);
@@ -43,16 +44,9 @@ export const beehiveFlow = async (args: string[]): Promise<void> => {
   }
 };
 
-export const getNpmTags = (cwd: string, packageName: string): Record<string, string> => {
-  const output = cp.execSync(`npm dist-tag ls @beehive-test/${packageName}`, { cwd }).toString();
-  const lines = output.split('\n').filter((x) => x.length > 0);
-  const r: Record<string, string> = {};
-
-  for (const line of lines) {
-    const [ tag, version ] = line.split(': ');
-    r[tag] = version;
-  }
-  return r;
+export const getNpmTags = async (cwd: string, packageName: string): Promise<Record<string, string>> => {
+  const tags = await NpmTags.getNpmTags(cwd, `@beehive-test/${packageName}`);
+  return ObjUtils.map(tags, versionToString);
 };
 
 export const readPjVersion = async (pjFile: string): Promise<string> => {

--- a/src/test/ts/core/BranchLogicTest.ts
+++ b/src/test/ts/core/BranchLogicTest.ts
@@ -91,12 +91,12 @@ describe('BranchLogic', () => {
       await assert.becomes(getBranchDetails(dir), expected);
     };
 
-    it('detects valid main branch', () =>
-      check('main', '0.6.0-alpha', BranchType.Main, BranchState.Main)
+    it('passes for main branch with rc version', () =>
+      check('main', '0.6.0-rc', BranchType.Main, BranchState.ReleaseCandidate)
     );
 
     it('passes for timestamped version on main branch', () =>
-      check('main', '0.6.0-alpha.20020202020202.293la9', BranchType.Main, BranchState.Main)
+      check('main', '0.6.0-rc.20020202020202.293la9', BranchType.Main, BranchState.ReleaseCandidate)
     );
 
     it('fails for main branch with wrong minor version', async () => {
@@ -104,17 +104,16 @@ describe('BranchLogic', () => {
       await assert.isRejected(getBranchDetails(dir));
     });
 
-    it('fails for main branch with rc version', async () => {
-      const { dir } = await setup('main', '0.6.0-rc');
+    it('fails for main branch with alpha version', async () => {
+      const { dir } = await setup('main', '0.6.0-alpha');
       await assert.isRejected(getBranchDetails(dir));
     });
 
-    it('fails for main branch with release version', async () => {
-      const { dir } = await setup('main', '0.6.0');
-      await assert.isRejected(getBranchDetails(dir));
+    it('passes for main branch with release version', async () => {
+      check('main', '0.6.0', BranchType.Main, BranchState.ReleaseReady)
     });
 
-    it('passes for main branch with prerelease version', async () => {
+    it('fails for main branch with non-rc prerelease version', async () => {
       const { dir } = await setup('main', '0.6.0+9nesste123.frog');
       await assert.isRejected(getBranchDetails(dir));
     });

--- a/src/test/ts/core/BranchLogicTest.ts
+++ b/src/test/ts/core/BranchLogicTest.ts
@@ -109,9 +109,9 @@ describe('BranchLogic', () => {
       await assert.isRejected(getBranchDetails(dir));
     });
 
-    it('passes for main branch with release version', async () => {
+    it('passes for main branch with release version', async () =>
       check('main', '0.6.0', BranchType.Main, BranchState.ReleaseReady)
-    });
+    );
 
     it('fails for main branch with non-rc prerelease version', async () => {
       const { dir } = await setup('main', '0.6.0+9nesste123.frog');

--- a/src/test/ts/core/NpmTagsTest.ts
+++ b/src/test/ts/core/NpmTagsTest.ts
@@ -19,15 +19,15 @@ const checkSimple = async (branchName: string, branchState: BranchState, version
 
 describe('NpmTags', () => {
   describe('pickTags', () => {
-    it('uses the branch name for feature branches', () => checkSimple('feature/BLAH-123', BranchState.Feature, '0.1.0', ['feature-BLAH-123']));
-    it('uses the branch name for spike branches', () => checkSimple('spike/BLAH-123', BranchState.Spike, '0.1.7', ['spike-BLAH-123']));
-    it('uses the branch name for hotfix branches', () => checkSimple('hotfix/BLAH-123', BranchState.Hotfix, '0.1.9', ['hotfix-BLAH-123']));
+    it('uses the branch name for feature branches', () => checkSimple('feature/BLAH-123', BranchState.Feature, '0.1.0', [ 'feature-BLAH-123' ]));
+    it('uses the branch name for spike branches', () => checkSimple('spike/BLAH-123', BranchState.Spike, '0.1.7', [ 'spike-BLAH-123' ]));
+    it('uses the branch name for hotfix branches', () => checkSimple('hotfix/BLAH-123', BranchState.Hotfix, '0.1.9', [ 'hotfix-BLAH-123' ]));
 
     it('uses the branch name and rc-version for main branch in releaseCandidate state', () =>
-      checkSimple('main', BranchState.ReleaseCandidate, '0.1.2-frog', ['main', 'rc-0.1'])
+      checkSimple('main', BranchState.ReleaseCandidate, '0.1.2-frog', [ 'main', 'rc-0.1' ])
     );
     it('uses the branch name, latest and release version for releaseReady main branch', () =>
-      checkSimple('main', BranchState.ReleaseReady, '0.1.2', ['main', 'latest', 'release-0.1'])
+      checkSimple('main', BranchState.ReleaseReady, '0.1.2', [ 'main', 'latest', 'release-0.1' ])
     );
 
     it('uses the branch name and rc-version for rc state', async () => {
@@ -38,11 +38,11 @@ describe('NpmTags', () => {
     });
 
     it('replaces sequences of characters other than alphanumeric/dot/underscore with dashes', () =>
-      checkSimple('hotfix/blah_32.7/b**@', BranchState.Hotfix, '0.1.2', ['hotfix-blah_32.7-b-'])
+      checkSimple('hotfix/blah_32.7/b**@', BranchState.Hotfix, '0.1.2', [ 'hotfix-blah_32.7-b-' ])
     );
 
     it('uses the branch name (replacing multiple slashes) for feature branches',
-      () => checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', ['feature-BLAH-12-3'])
+      () => checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', [ 'feature-BLAH-12-3' ])
     );
 
     it('uses no tags for release ready state if not the latest release branch', async () => {

--- a/src/test/ts/core/NpmTagsTest.ts
+++ b/src/test/ts/core/NpmTagsTest.ts
@@ -5,6 +5,7 @@ import * as NpmTags from '../../../main/ts/core/NpmTags';
 import { BranchState } from '../../../main/ts/core/BranchLogic';
 import * as PromiseUtils from '../../../main/ts/utils/PromiseUtils';
 import { parseVersion } from '../../../main/ts/core/Version';
+import * as ArrayUtils from '../../../main/ts/utils/ArrayUtils';
 
 const assert = chai.use(chaiAsPromised).assert;
 const succeed = PromiseUtils.succeed;
@@ -17,74 +18,182 @@ const checkSimple = async (branchName: string, branchState: BranchState, version
   );
 };
 
+const assertSorted = <A> (actual: A[], expected: A[]): void => {
+  assert.deepEqual(ArrayUtils.sort(actual), ArrayUtils.sort(expected));
+};
+
 describe('NpmTags', () => {
   describe('pickTags', () => {
-    it('uses the branch name for feature branches', () => checkSimple('feature/BLAH-123', BranchState.Feature, '0.1.0', [ 'feature-BLAH-123' ]));
-    it('uses the branch name for spike branches', () => checkSimple('spike/BLAH-123', BranchState.Spike, '0.1.7', [ 'spike-BLAH-123' ]));
-    it('uses the branch name for hotfix branches', () => checkSimple('hotfix/BLAH-123', BranchState.Hotfix, '0.1.9', [ 'hotfix-BLAH-123' ]));
+    describe('feature branches', () => {
+      it('uses the branch name', () =>
+        checkSimple('feature/BLAH-123', BranchState.Feature, '0.1.0', [ 'feature-BLAH-123' ])
+      );
 
-    it('uses the branch name and rc-version for main branch in releaseCandidate state', () =>
-      checkSimple('main', BranchState.ReleaseCandidate, '0.1.2-frog', [ 'main', 'rc-0.1' ])
-    );
-    it('uses the branch name, latest and release version for releaseReady main branch', () =>
-      checkSimple('main', BranchState.ReleaseReady, '0.1.2', [ 'main', 'latest', 'release-0.1' ])
-    );
+      it('replaces multiple slashes', () =>
+        checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', [ 'feature-BLAH-12-3' ])
+      );
 
-    it('uses the branch name and rc-version for rc state', async () => {
-      await assert.becomes(
-        NpmTags.pickTags('release/9.12', BranchState.ReleaseCandidate, await parseVersion('9.12.0-rc'), () => succeed([ 'release/9.12' ])),
-        [ 'rc-9.12' ]
+    });
+
+    describe('spike branches', () => {
+      it('uses the branch name', () =>
+        checkSimple('spike/BLAH-123', BranchState.Spike, '0.1.7', [ 'spike-BLAH-123' ]));
+    });
+
+    describe('hotfix branches', () => {
+      it('uses the branch name for hotfix branches', () =>
+        checkSimple('hotfix/BLAH-123', BranchState.Hotfix, '0.1.9', [ 'hotfix-BLAH-123' ])
+      );
+
+      it('replaces sequences of characters other than alphanumeric/dot/underscore with dashes', () =>
+        checkSimple('hotfix/blah_32.7/b**@', BranchState.Hotfix, '0.1.2', [ 'hotfix-blah_32.7-b-' ])
       );
     });
 
-    it('replaces sequences of characters other than alphanumeric/dot/underscore with dashes', () =>
-      checkSimple('hotfix/blah_32.7/b**@', BranchState.Hotfix, '0.1.2', [ 'hotfix-blah_32.7-b-' ])
-    );
+    describe('main branch', () => {
+      describe('release ready state', () => {
+        it('does not use "latest" if version less than current latest', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('6.7.23'),
+              async () => ({ latest: await parseVersion('6.7.24') })),
+            [ 'main', 'release-6.7' ]
+          );
+        });
 
-    it('uses the branch name (replacing multiple slashes) for feature branches',
-      () => checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', [ 'feature-BLAH-12-3' ])
-    );
+        it('uses "latest" if version equal to the current latest', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('6.7.22'),
+              async () => ({ latest: await parseVersion('6.7.22') })),
+            [ 'main', 'release-6.7', 'latest' ]
+          );
+        });
 
-    it('uses no tags for release ready state if not the latest release branch', async () => {
-      await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.6'), () => succeed([ 'release/1.2', 'release/1.7' ])),
-        [ 'release-1.2' ]
-      );
-      await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.9'), () => succeed([ 'release/1.2', 'release/1.3', 'main' ])),
-        [ 'release-1.2' ]
-      );
-      await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.92'), () => succeed([ 'release/2.0', 'feature/1.2' ])),
-        [ 'release-1.2' ]
-      );
+        it('uses "latest" if version greater than the current latest', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('8.1.0'),
+              async () => ({ latest: await parseVersion('8.1.0-rc') })),
+            [ 'main', 'release-8.1', 'latest' ]
+          );
+        });
+
+        it('uses "latest" if current latest is any rc build', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('0.1.11'),
+              async () => ({ latest: await parseVersion('0.1.11-rc') })),
+            [ 'main', 'release-0.1', 'latest' ]
+          );
+
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('0.1.11'),
+              async () => ({ latest: await parseVersion('400.1.11-rc') })),
+            [ 'main', 'release-0.1', 'latest' ]
+          );
+        });
+
+        it('uses "latest" if there is no existing "latest" tag', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseReady, await parseVersion('8.1.0'),
+              () => succeed({})),
+            [ 'main', 'release-8.1', 'latest' ]
+          );
+        });
+      });
+
+      describe('rc state', () => {
+        it('uses "latest" for rc state if there is no existing "latest" tag', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+              () => succeed({})),
+            [ 'main', 'rc-8.1', 'latest' ]
+          );
+        });
+
+        it('uses "latest" for rc state if equal to existing "latest" tag', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+              async () => ({ latest: await parseVersion('8.1.0-rc') })),
+            [ 'main', 'rc-8.1', 'latest' ]
+          );
+        });
+
+        it('uses "latest" for rc state if greater to existing "latest" tag', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+              async () => ({ latest: await parseVersion('8.0.99-rc') })),
+            [ 'main', 'rc-8.1', 'latest' ]
+          );
+        });
+
+        it('does not use "latest" for rc state if less than existing "latest" tag', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+              async () => ({ latest: await parseVersion('8.1.1-rc') })),
+            [ 'main', 'rc-8.1' ]
+          );
+        });
+
+        it('does not use "latest" for rc state if latest is a real release', async () => {
+          assertSorted(
+            await NpmTags.pickTags('main', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+              async () => ({ latest: await parseVersion('0.0.1') })),
+            [ 'main', 'rc-8.1' ]
+          );
+        });
+      });
     });
 
-    it('uses "latest" for release ready state if it is the latest release branch', async () => {
-      await assert.becomes(
-        NpmTags.pickTags('release/6.7', BranchState.ReleaseReady, await parseVersion('6.7.22'),
-          () => succeed([ 'main', 'frog', 'release/6.7', 'release/6.6', 'feature/1.2' ])),
-        [ 'release-6.7', 'latest' ]
-      );
+    describe('release branches', () => {
+      it('does not use "latest" for release ready state if not the latest release', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.6'), async () => ({ latest: await parseVersion('1.3.8') })),
+          [ 'release-1.2' ]
+        );
+        assertSorted(
+          await NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('1.2.9'), async () => ({ latest: await parseVersion('2.4.0') })),
+          [ 'release-1.2' ]
+        );
+      });
 
-      await assert.becomes(
-        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.0'),
-          () => succeed([ 'release/8.1', 'main', 'frog', 'release/6.7', 'release/8.0', 'release/6.6', 'feature/1.2' ])),
-        [ 'release-8.1', 'latest' ]
-      );
+      it('uses "latest" for release ready state if it version equal to the current latest', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/6.7', BranchState.ReleaseReady, await parseVersion('6.7.22'),
+            async () => ({ latest: await parseVersion('6.7.22') })),
+          [ 'release-6.7', 'latest' ]
+        );
+      });
 
-      await assert.becomes(
-        NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.12'),
-          () => succeed([ 'main', 'frog', 'release/6.7', 'release/6.6', 'feature/1.2', 'release/8.1' ])),
-        [ 'release-8.1', 'latest' ]
-      );
-    });
 
-    it('does not tag latest if no release branches can be found', async () => {
-      await assert.becomes(
-        NpmTags.pickTags('release/1.2', BranchState.ReleaseReady, await parseVersion('8.1.11'), () => succeed([])),
-        [ 'release-1.2' ]
-      );
+      it('uses "latest" for release ready state if version is a release, but current latest is an earlier rc', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/0.1', BranchState.ReleaseReady, await parseVersion('0.1.11'),
+            async () => ({ latest: await parseVersion('0.1.11-rc') })),
+          [ 'release-0.1', 'latest' ]
+        );
+      });
+
+      it('uses "latest" for release ready state if it is greater than the current latest', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.0'),
+            async () => ({ latest: await parseVersion('8.1.0-rc') })),
+          [ 'release-8.1', 'latest' ]
+        );
+      });
+
+      it('uses "latest" for release ready state if there is no existing "latest" tag', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/8.1', BranchState.ReleaseReady, await parseVersion('8.1.0'),
+            () => succeed({})),
+          [ 'release-8.1', 'latest' ]
+        );
+      });
+
+      it('uses "latest" for rc state if there is no existing "latest" tag', async () => {
+        assertSorted(
+          await NpmTags.pickTags('release/8.1', BranchState.ReleaseCandidate, await parseVersion('8.1.0-rc'),
+            () => succeed({})),
+          [ 'rc-8.1', 'latest' ]
+        );
+      });
     });
   });
 });

--- a/src/test/ts/core/VersionTest.ts
+++ b/src/test/ts/core/VersionTest.ts
@@ -3,11 +3,7 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import fc from 'fast-check';
 import * as Version from '../../../main/ts/core/Version';
-import * as PromiseUtils from '../../../main/ts/utils/PromiseUtils';
 import { Comparison } from '../../../main/ts/utils/Comparison';
-
-type Arbitrary<A> = fc.Arbitrary<A>;
-type MajorMinorVersion = Version.MajorMinorVersion;
 
 const assert = chai.use(chaiAsPromised).assert;
 
@@ -115,35 +111,6 @@ describe('Version', () => {
           assert.deepEqual(actual, input);
         }
       ));
-    });
-  });
-
-  describe('sortMajorMinorVersions', () => {
-    const arbmm = (): Arbitrary<MajorMinorVersion> => fc.tuple(fc.nat(300), fc.nat(300)).map(([ major, minor ]) => ({ major, minor }));
-
-    it('returns the same length array', () => {
-      fc.assert(fc.property(fc.array(arbmm()), (mms) => {
-        assert.equal(
-          Version.sortMajorMinorVersions(mms).length,
-          mms.length
-        );
-      }));
-    });
-
-    it('sorts', async () => {
-      const check = async (sInput: string[], sExpected: string[]): Promise<void> => {
-        const mmInput = await PromiseUtils.parMap(sInput, Version.parseMajorMinorVersion);
-        const mmOutput = Version.sortMajorMinorVersions(mmInput);
-        const sOutput = mmOutput.map(Version.majorMinorVersionToString);
-        assert.deepEqual(sOutput, sExpected);
-      };
-      await check([], []);
-      await check([ '3.4' ], [ '3.4' ]);
-      await check([ '1.0', '2.0' ], [ '1.0', '2.0' ]);
-      await check([ '2.0', '1.0' ], [ '1.0', '2.0' ]);
-      await check([ '1.100', '1.10' ], [ '1.10', '1.100' ]);
-      await check([ '1.2', '1.10' ], [ '1.2', '1.10' ]);
-      await check([ '1.10', '1.0' ], [ '1.0', '1.10' ]);
     });
   });
 


### PR DESCRIPTION
Publishing from main.

Changed main branch prerelease from "alpha" to "rc".

Rewrote publish tests. The old tests were doing a series of publishes in one test case, so it was hard to know what failed.

Changed logic for "latest" tag. It was based on branches, but that wouldn't work when publishing from main. Now it looks at the existing NPM tags.

Changed the field name for latest on the Status command.

Added some machinery for sorting and comparing things. I can't deal with this business of < 0 meaning less-than. Breaks my head. fp-ts' implementation uses `-1 | 0 | 1` which isn't ideal.

Rewrote the process description in the readme. Hopefully this helps people understand it quicker.

The readme describes how we now have two process variants.