### PR TITLE
Now tags as `X.Y.Z` instead of `module@X.Y.Z`. The latter form will…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
  - Prep work for monorepo support. #TINY-6986, #TINY-6987
 
 ### Changed
- - Now tags as `vX.Y.Z` instead of `module@vX.Y.Z`. The latter form will be used for non-primary modules of monorepos. #TINY-7026
+ - Now tags as `X.Y.Z` instead of `module@X.Y.Z`. The latter form will be used for non-primary modules of monorepos. #TINY-7026
 
 ## [0.13.0] - 2021-02-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,25 @@
 ## [Unreleased]
+### Added
+ - Prep work for monorepo support. #TINY-6986, #TINY-6987
 
-## [0.12.0] - unreleased
-- publish from main branch
-- tag greatest prerelease version as latest if no prior release versions
-- change output of status command
+### Changed
+ - Now tags as `vX.Y.Z` instead of `module@vX.Y.Z`. The latter form will be used for non-primary modules of monorepos. #TINY-7026
+
+## [0.13.0] - 2021-02-02
+### Changed
+ - Publishing beehive-flow from main branch. #TINY-6890
+ 
+## [0.12.0] - 2021-01-27
+### Changed
+ - Publish from main branch
+ - Tag greatest prerelease version as latest if no prior release versions
+ - Change output of status command
 
 ## [0.11.0] - 2021-01-11
 ### Added
-- `beehive-flow publish --dist-dir` setting
-- `beehive-flow status` command
+ - `beehive-flow publish --dist-dir` setting
+ - `beehive-flow status` command
 
 ## [0.10.0] - 2021-01-07
 ### Added
-- Initial implementation. 
+ - Initial implementation. 

--- a/src/main/ts/commands/Publish.ts
+++ b/src/main/ts/commands/Publish.ts
@@ -61,7 +61,17 @@ const npmTag = async (args: PublishArgs, tags: string[], r: BranchDetails, dir: 
 
 const gitTag = async (r: BranchDetails, git: gitP.SimpleGit, args: PublishArgs): Promise<void> => {
   if (r.branchState === BranchState.ReleaseReady) {
-    const tagName = r.packageJson.name + '@' + Version.versionToString(r.version);
+
+    // TODO TINY-6994: Implement tagging logic:
+    /*
+      Tag X.Y.Z for the primary module in a repo.
+      In a single-module repo this will be the one and only module.
+      For a multi-project repos this might be the root module (which might not be published) or a special project.
+      Tag package@X.Y.Z for all modules other than the primary.
+     */
+    // const tagName = r.packageJson.name + '@' + Version.versionToString(r.version);
+    const tagName = Version.versionToString(r.version);
+
     console.log(`Tagging as ${tagName}`);
     await git.addTag(tagName);
 

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -92,14 +92,14 @@ describe('Publish', () => {
   }).timeout(TIMEOUT);
 
   it('publishes release from main branch', async () => {
-    const { npmTags, gitTags, packageName } = await runScenario('main', '0.1.0', false);
+    const { npmTags, gitTags } = await runScenario('main', '0.1.0', false);
     assert.deepEqual(npmTags, {
       'feature-dummy': '0.0.1-rc',
       'main': '0.1.0',
       'latest': '0.1.0',
       'release-0.1': '0.1.0'
     });
-    assert.deepEqual(gitTags, [ `@beehive-test/${packageName}@0.1.0` ]);
+    assert.deepEqual(gitTags, [ '0.1.0' ]);
   }).timeout(TIMEOUT);
 
   it('publishes rc from release branch', async () => {
@@ -113,13 +113,13 @@ describe('Publish', () => {
   }).timeout(TIMEOUT);
 
   it('publishes release from release branch', async () => {
-    const { npmTags, gitTags, packageName } = await runScenario('release/0.5', '0.5.444', false);
+    const { npmTags, gitTags } = await runScenario('release/0.5', '0.5.444', false);
     assert.deepEqual(npmTags, {
       'feature-dummy': '0.0.1-rc',
       'latest': '0.5.444',
       'release-0.5': '0.5.444'
     });
-    assert.deepEqual(gitTags, [ `@beehive-test/${packageName}@0.5.444` ]);
+    assert.deepEqual(gitTags, [ '0.5.444' ]);
   }).timeout(TIMEOUT);
 
   it('publishes from feature branch', async () => {
@@ -210,6 +210,6 @@ describe('Publish', () => {
     assert.deepEqual(depPj.dependencies, {});
 
     const gitTags = (await git.tags()).all.sort();
-    assert.deepEqual(gitTags, [ '@beehive-test/beehive-test-dist-dir@1.1.3' ]);
+    assert.deepEqual(gitTags, [ '1.1.3' ]);
   }).timeout(120000); // Verdaccio runs pretty slowly on the build servers
 });


### PR DESCRIPTION
… be used for non-primary modules of monorepos. #TINY-7026