### PR TITLE
TINY-7333: Changed the prerelease stamp version to prefix the hash with "sha"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Changed
+ - The prerelease version created by the `stamp` command will now prefix the git hash with "sha". #TINY-7333
+
+### Fixed
+ - Certain unexpected errors would incorrectly print `[Object object]` instead of the object data.
+ - Command header messages weren't being printed to the console.
+
 ## [0.14.0] - 2021-02-16
 ### Added
  - Prep work for monorepo support. #TINY-6986, #TINY-6987

--- a/src/main/ts/Main.ts
+++ b/src/main/ts/Main.ts
@@ -10,7 +10,7 @@ const main = async () => {
 };
 
 main().catch((e: unknown) => {
-  const msg = e instanceof Error ? e.message : String(e);
+  const msg = e instanceof Error ? e.message : JSON.stringify(e);
   console.error(msg);
   process.exit(1);
 });

--- a/src/main/ts/commands/Stamp.ts
+++ b/src/main/ts/commands/Stamp.ts
@@ -34,7 +34,7 @@ export const chooseNewVersion = (branchState: BranchState, version: Version, git
     })();
 
     const dt = formatDate(timeMillis);
-    const preRelease = `${prePre}.${dt}.${gitSha}`;
+    const preRelease = `${prePre}.${dt}.sha${gitSha}`;
 
     const buildMetaData = undefined;
 

--- a/src/main/ts/core/Messages.ts
+++ b/src/main/ts/core/Messages.ts
@@ -2,8 +2,8 @@ import * as BeehiveArgs from '../args/BeehiveArgs';
 
 type BeehiveArgs = BeehiveArgs.BeehiveArgs;
 
-export const printHeaderMessage = (args: BeehiveArgs): string => {
+export const printHeaderMessage = (args: BeehiveArgs): void => {
   const cmd = BeehiveArgs.commandName(args);
   const dryRunMessage = args.dryRun ? ' (dry-run)' : '';
-  return `Running: ${cmd} ${dryRunMessage}`;
+  console.log(`Running: ${cmd} ${dryRunMessage}`);
 };

--- a/src/test/ts/commands/StampTest.ts
+++ b/src/test/ts/commands/StampTest.ts
@@ -26,7 +26,7 @@ describe('Stamp', () => {
 
     it('makes a timestamped version on main branch', async () => {
       const actual = Stamp.chooseNewVersion(BranchState.ReleaseCandidate, await Version.parseVersion('1.2.0-alpha'), 'b0d52ad', timeMillis);
-      assert.equal(Version.versionToString(actual), `1.2.0-alpha.${timeFormatted}.b0d52ad`);
+      assert.equal(Version.versionToString(actual), `1.2.0-alpha.${timeFormatted}.shab0d52ad`);
     });
 
     it('makes a timestamped version on feature branch', async () => {
@@ -34,18 +34,18 @@ describe('Stamp', () => {
         const patch = 0;
         const v = `${major}.${minor}.${patch}-main`;
         const actual = Stamp.chooseNewVersion(BranchState.Feature, await Version.parseVersion(v), 'b0d59ad', timeMillis);
-        assert.equal(Version.versionToString(actual), `${major}.${minor}.${patch}-feature.${timeFormatted}.b0d59ad`);
+        assert.equal(Version.versionToString(actual), `${major}.${minor}.${patch}-feature.${timeFormatted}.shab0d59ad`);
       }));
     });
 
     it('makes a timestamped version on hotfix branch', async () => {
       const actual = Stamp.chooseNewVersion(BranchState.Hotfix, await Version.parseVersion('1.2.0-rc'), 'f0d52ad', timeMillis);
-      assert.equal(Version.versionToString(actual), `1.2.0-hotfix.${timeFormatted}.f0d52ad`);
+      assert.equal(Version.versionToString(actual), `1.2.0-hotfix.${timeFormatted}.shaf0d52ad`);
     });
 
     it('makes a timestamped version in rc state', async () => {
       const actual = Stamp.chooseNewVersion(BranchState.ReleaseCandidate, await Version.parseVersion('1.2.0-rc'), 'f0d52ad', timeMillis);
-      assert.equal(Version.versionToString(actual), `1.2.0-rc.${timeFormatted}.f0d52ad`);
+      assert.equal(Version.versionToString(actual), `1.2.0-rc.${timeFormatted}.shaf0d52ad`);
     });
 
     it('does not change version for release version', async () => {


### PR DESCRIPTION
Related Ticket: TINY-7333

Description:
- Changes the stamp command to use the `sha` prefix so that an invalid prerelease version isn't generated when the git SHA starts with a `0`.
- Fixed a couple other minor bugs that made this issue harder to identify.