### PR TITLE
TINY-7474: Added new revive command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [Unreleased]
+### Added
+ - `beehive-flow revive a.b` command to recreate a release branch from tags. #TINY-7474
+
+### Fixed
+ - The `prepare` command would incorrectly reset the release branch patch version back to 0.
 
 ## [0.15.0] - 2021-04-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -291,6 +291,19 @@ if (beehiveFlowStatus.branchState == 'releaseReady' && beehiveFlowStatus.isLates
 }
 ```
 
+### revive a.b
+
+This command allows a `release/a.b` branch to be created from previous release tags. This is useful if a hotfix needs to be backported to an older version. This command does the following:
+
+1. Finds all tags that match the specified `a.b` version.
+2. Sorts the tags and determines the most recent patch release.
+3. Creates the new `release/a.b` branch from the tag.
+4. Advances the version to the next RC patch release.
+
+Version changes:
+
+- `release/a.b`: `a.b.c` -> `a.b.c-rc`
+
 ## CI Instructions
 
 CI needs to check out a real branch, not just a detached head.

--- a/src/main/ts/args/BeehiveArgs.ts
+++ b/src/main/ts/args/BeehiveArgs.ts
@@ -42,6 +42,13 @@ export interface StatusArgs extends BaseArgs {
   readonly kind: 'StatusArgs';
 }
 
+export interface ReviveArgs extends BaseArgs {
+  readonly kind: 'ReviveArgs';
+  readonly temp: Option<string>;
+  readonly branchName: string;
+  readonly gitUrl: Option<string>;
+}
+
 export const prepareArgs = (dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>): PrepareArgs => ({
   kind: 'PrepareArgs',
   dryRun,
@@ -97,7 +104,18 @@ export const statusArgs = (dryRun: boolean, workingDir: string): StatusArgs => (
   workingDir
 });
 
-export type BeehiveArgs = PrepareArgs | ReleaseArgs | AdvanceArgs | AdvanceCiArgs | StampArgs | PublishArgs | StatusArgs;
+export const reviveArgs = (
+  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string
+): ReviveArgs => ({
+  kind: 'ReviveArgs',
+  dryRun,
+  workingDir,
+  temp,
+  gitUrl,
+  branchName
+});
+
+export type BeehiveArgs = PrepareArgs | ReleaseArgs | AdvanceArgs | AdvanceCiArgs | StampArgs | PublishArgs | StatusArgs | ReviveArgs;
 
 export const fold = <T>(
   bh: BeehiveArgs,
@@ -107,7 +125,8 @@ export const fold = <T>(
   ifAdvanceCi: (a: AdvanceCiArgs) => T,
   ifStamp: (a: StampArgs) => T,
   ifPublish: (a: PublishArgs) => T,
-  ifStatus: (a: StatusArgs) => T
+  ifStatus: (a: StatusArgs) => T,
+  ifRevive: (a: ReviveArgs) => T
 ): T => {
   switch (bh.kind) {
     case 'PrepareArgs':
@@ -124,8 +143,19 @@ export const fold = <T>(
       return ifPublish(bh);
     case 'StatusArgs':
       return ifStatus(bh);
+    case 'ReviveArgs':
+      return ifRevive(bh);
   }
 };
 
 export const commandName = (bh: BeehiveArgs): string =>
-  fold(bh, () => 'prepare', () => 'release', () => 'advance', () => 'advance-ci', () => 'stamp', () => 'publish', () => 'status');
+  fold(bh,
+    () => 'prepare',
+    () => 'release',
+    () => 'advance',
+    () => 'advance-ci',
+    () => 'stamp',
+    () => 'publish',
+    () => 'status',
+    () => 'revive'
+  );

--- a/src/main/ts/args/Dispatch.ts
+++ b/src/main/ts/args/Dispatch.ts
@@ -3,6 +3,7 @@ import * as Release from '../commands/Release';
 import * as Advance from '../commands/Advance';
 import * as Stamp from '../commands/Stamp';
 import * as Publish from '../commands/Publish';
+import * as Revive from '../commands/Revive';
 import * as Status from '../commands/Status';
 import * as BeehiveArgs from './BeehiveArgs';
 
@@ -17,6 +18,7 @@ export const dispatch = (args: BeehiveArgs): Promise<void> =>
     Advance.advanceCi,
     Stamp.stamp,
     Publish.publish,
-    Status.status
+    Status.status,
+    Revive.revive
   );
 

--- a/src/main/ts/commands/Prepare.ts
+++ b/src/main/ts/commands/Prepare.ts
@@ -1,79 +1,16 @@
-import * as path from 'path';
-import * as PropertiesReader from 'properties-reader';
-import * as O from 'fp-ts/Option';
 import { SimpleGit } from 'simple-git';
 import * as Git from '../utils/Git';
-import * as PackageJson from '../core/PackageJson';
-import { BranchState, BranchDetails, getBranchDetails, getReleaseBranchName } from '../core/BranchLogic';
-import * as Files from '../utils/Files';
+import { BranchState, BranchDetails, getBranchDetails, getReleaseBranchName, createReleaseBranch } from '../core/BranchLogic';
 import { PrepareArgs } from '../args/BeehiveArgs';
-import { Version } from '../core/Version';
+import * as AdvanceVersion from '../core/AdvanceVersion';
 import * as PromiseUtils from '../utils/PromiseUtils';
-import * as PreRelease from '../core/PreRelease';
 import { printHeaderMessage } from '../core/Messages';
 
-type PackageJson = PackageJson.PackageJson;
-
-const writeBuildPropertiesFile = async (dir: string, releaseBranchName: string): Promise<string> => {
-  const buildPropertiesFile = path.resolve(dir, 'build.properties');
-  if (!await Files.exists(buildPropertiesFile)) {
-    console.log(`${buildPropertiesFile} does not exist: creating`);
-    await Files.writeFile(buildPropertiesFile, '');
-  }
-
-  console.log(`Updating properties file: ${buildPropertiesFile}`);
-  const props = PropertiesReader(buildPropertiesFile);
-  props.set('primaryBranch', releaseBranchName);
-  await props.save(buildPropertiesFile);
-  return buildPropertiesFile;
-};
-
-export const newMainBranchVersion = (oldMainBranchVersion: Version): Version => ({
-  major: oldMainBranchVersion.major,
-  minor: oldMainBranchVersion.minor + 1,
-  patch: 0,
-  preRelease: PreRelease.releaseCandidate
-});
-
-export const releaseBranchVersion = (oldMainBranchVersion: Version): Version => ({
-  major: oldMainBranchVersion.major,
-  minor: oldMainBranchVersion.minor,
-  patch: 0,
-  preRelease: PreRelease.releaseCandidate
-});
-
-const updatePackageJsonFileForReleaseBranch = async (version: Version, pj: PackageJson, pjFile: string): Promise<void> => {
-  const branchVersion = releaseBranchVersion(version);
-  const newPj = PackageJson.setVersion(pj, O.some(branchVersion));
-  await PackageJson.writePackageJsonFile(pjFile, newPj);
-};
-
-const updatePackageJsonFileForMainBranch = async (version: Version, pj: PackageJson, pjFile: string): Promise<Version> => {
-  const newMainVersion = newMainBranchVersion(version);
-  const newPj = PackageJson.setVersion(pj, O.some(newMainVersion));
-  await PackageJson.writePackageJsonFile(pjFile, newPj);
-  return newMainVersion;
-};
-
-const createReleaseBranch = async (releaseBranchName: string, git: SimpleGit, dir: string, branchDetails: BranchDetails, args: PrepareArgs): Promise<void> => {
-  console.log(`Creating ${releaseBranchName} branch`);
-  await Git.checkoutNewBranch(git, releaseBranchName);
-  const buildPropertiesFile = await writeBuildPropertiesFile(dir, releaseBranchName);
-  const rootModule = branchDetails.rootModule;
-  await updatePackageJsonFileForReleaseBranch(branchDetails.version, rootModule.packageJson, rootModule.packageJsonFile);
-  await git.add([ buildPropertiesFile, rootModule.packageJsonFile ]);
-  await git.commit(`Creating release branch: ${releaseBranchName}`);
-  await Git.pushUnlessDryRun(dir, git, args.dryRun);
-};
-
-const updateMainBranch = async (mainBranch: string, git: SimpleGit, branchDetails: BranchDetails, args: PrepareArgs, dir: string): Promise<void> => {
+const updateMainBranch = async (mainBranch: string, git: SimpleGit, branchDetails: BranchDetails): Promise<void> => {
   console.log(`Updating ${mainBranch} branch`);
   await git.checkout(mainBranch);
   const rootModule = branchDetails.rootModule;
-  await updatePackageJsonFileForMainBranch(branchDetails.version, rootModule.packageJson, rootModule.packageJsonFile);
-  await git.add(rootModule.packageJsonFile);
-  await git.commit(`Updating version`);
-  await Git.pushUnlessDryRun(dir, git, args.dryRun);
+  await AdvanceVersion.advanceMinor(branchDetails.version, rootModule.packageJson, rootModule.packageJsonFile, git);
 };
 
 export const prepare = async (args: PrepareArgs): Promise<void> => {
@@ -92,6 +29,12 @@ export const prepare = async (args: PrepareArgs): Promise<void> => {
   const releaseBranchName = getReleaseBranchName(branchDetails.version);
 
   await Git.branchShouldNotExist(git, releaseBranchName);
-  await createReleaseBranch(releaseBranchName, git, dir, branchDetails, args);
-  await updateMainBranch(mainBranch, git, branchDetails, args, dir);
+
+  // Create the release branch
+  await createReleaseBranch(releaseBranchName, git, dir);
+  await Git.pushUnlessDryRun(dir, git, args.dryRun);
+
+  // Update the main branch
+  await updateMainBranch(mainBranch, git, branchDetails);
+  await Git.pushUnlessDryRun(dir, git, args.dryRun);
 };

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -1,6 +1,7 @@
 import { ReleaseArgs } from '../args/BeehiveArgs';
 import * as Version from '../core/Version';
 import * as Git from '../utils/Git';
+import * as AdvanceVersion from '../core/AdvanceVersion';
 import * as PackageJson from '../core/PackageJson';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { BranchState, getBranchDetails } from '../core/BranchLogic';
@@ -8,12 +9,6 @@ import { printHeaderMessage } from '../core/Messages';
 
 type Version = Version.Version;
 const { versionToString } = Version;
-
-export const updateVersion = (version: Version): Version => ({
-  major: version.major,
-  minor: version.minor,
-  patch: version.patch
-});
 
 export const release = async (args: ReleaseArgs): Promise<void> => {
   printHeaderMessage(args);
@@ -28,7 +23,7 @@ export const release = async (args: ReleaseArgs): Promise<void> => {
     return PromiseUtils.fail('Branch is not in Release Candidate state - can\'t release.');
   }
 
-  const newVersion = updateVersion(branchDetails.version);
+  const newVersion = AdvanceVersion.updateToStable(branchDetails.version);
   console.log(`Updating version from ${versionToString(branchDetails.version)} to ${versionToString(newVersion)}`);
 
   const rootModule = branchDetails.rootModule;

--- a/src/main/ts/commands/Revive.ts
+++ b/src/main/ts/commands/Revive.ts
@@ -1,0 +1,70 @@
+import * as O from 'fp-ts/Option';
+import { pipe } from 'fp-ts/function';
+import { SimpleGit } from 'simple-git';
+import { ReviveArgs } from '../args/BeehiveArgs';
+import { createReleaseBranch, getBranchDetails, getReleaseBranchName, versionFromReleaseBranch } from '../core/BranchLogic';
+import * as AdvanceVersion from '../core/AdvanceVersion';
+import { printHeaderMessage } from '../core/Messages';
+import * as Version from '../core/Version';
+import * as ArrayUtils from '../utils/ArrayUtils';
+import { Comparison } from '../utils/Comparison';
+import * as OptionUtils from '../utils/OptionUtils';
+import * as PromiseUtils from '../utils/PromiseUtils';
+import * as Git from '../utils/Git';
+
+type MajorMinorVersion = Version.MajorMinorVersion;
+type Version = Version.Version;
+
+interface TagDetails {
+  readonly version: Version;
+  readonly name: string;
+}
+
+const getLatestTag = async (git: SimpleGit, version: MajorMinorVersion): Promise<TagDetails> => {
+  const tags = await Git.getTags(git);
+  const tagDetails = OptionUtils.somes(tags.map((tag) => pipe(
+    Version.parseVersionE(tag),
+    O.fromEither,
+    O.filter((v) => Version.compareMajorMinorVersions(v, version) === Comparison.EQ),
+    O.map((v) => ({
+      version: v,
+      name: tag
+    }))
+  )));
+  const sortedDetails = ArrayUtils.sort(tagDetails, (td1, td2) => Version.compareVersions(td1.version, td2.version));
+  return PromiseUtils.optionToPromise(
+    O.fromNullable(sortedDetails[sortedDetails.length - 1]),
+    `Failed to find any tags matching version: ${Version.majorMinorVersionToString(version)}`
+  );
+};
+
+export const revive = async (args: ReviveArgs): Promise<void> => {
+  printHeaderMessage(args);
+  const gitUrl = await Git.resolveGitUrl(args.gitUrl, args.workingDir);
+  const { dir, git } = await Git.cloneInTempFolder(gitUrl, args.temp);
+
+  // Verify the branch doesn't already exist
+  await Git.branchShouldNotExist(git, args.branchName);
+
+  // Verify we're not trying to setup the version for something that's in main
+  const version = await versionFromReleaseBranch(args.branchName);
+  await Git.checkoutMainBranch(git);
+  const mainBranchDetails = await getBranchDetails(dir);
+  if (Version.compareMajorMinorVersions(mainBranchDetails.version, version) === Comparison.EQ) {
+    return PromiseUtils.fail(`main branch is still at version: ${Version.majorMinorVersionToString(version)}`);
+  }
+
+  // Find the latest git tag that matches the release branch to be created
+  const latestTag = await getLatestTag(git, version);
+  await Git.checkout(git, latestTag.name);
+
+  // Rebuild the release branch from the tag
+  const releaseBranchName = getReleaseBranchName(latestTag.version);
+  await createReleaseBranch(releaseBranchName, git, dir);
+  const branchDetails = await getBranchDetails(dir);
+
+  // Advance the version to the new patch release
+  const rootModule = branchDetails.rootModule;
+  await AdvanceVersion.advancePatch(latestTag.version, rootModule.packageJson, rootModule.packageJsonFile, git);
+  await Git.pushUnlessDryRun(dir, git, args.dryRun);
+};

--- a/src/main/ts/commands/Revive.ts
+++ b/src/main/ts/commands/Revive.ts
@@ -20,7 +20,7 @@ interface TagDetails {
   readonly name: string;
 }
 
-const getLatestTag = async (git: SimpleGit, version: MajorMinorVersion): Promise<TagDetails> => {
+const getLatestTagForVersion = async (git: SimpleGit, version: MajorMinorVersion): Promise<TagDetails> => {
   const tags = await Git.getTags(git);
   const tagDetails = OptionUtils.somes(tags.map((tag) => pipe(
     Version.parseVersionE(tag),
@@ -55,7 +55,7 @@ export const revive = async (args: ReviveArgs): Promise<void> => {
   }
 
   // Find the latest git tag that matches the release branch to be created
-  const latestTag = await getLatestTag(git, version);
+  const latestTag = await getLatestTagForVersion(git, version);
   await Git.checkout(git, latestTag.name);
 
   // Rebuild the release branch from the tag

--- a/src/main/ts/core/AdvanceVersion.ts
+++ b/src/main/ts/core/AdvanceVersion.ts
@@ -1,0 +1,44 @@
+import { SimpleGit } from 'simple-git';
+import * as PackageJson from './PackageJson';
+import * as PreRelease from './PreRelease';
+import { Version, versionToString } from './Version';
+
+type PackageJson = PackageJson.PackageJson;
+
+export const updateToNextPatch = (version: Version): Version => ({
+  major: version.major,
+  minor: version.minor,
+  patch: version.patch + 1,
+  preRelease: PreRelease.releaseCandidate
+});
+
+export const updateToNextMinor = (version: Version): Version => ({
+  major: version.major,
+  minor: version.minor + 1,
+  patch: 0,
+  preRelease: PreRelease.releaseCandidate
+});
+
+export const updateToStable = (version: Version): Version => ({
+  major: version.major,
+  minor: version.minor,
+  patch: version.patch
+});
+
+const advance = async (version: Version, pj: PackageJson, pjFile: string, advanceVersion: (version: Version) => Version) => {
+  const newVersion = advanceVersion(version);
+  console.log(`Updating version from ${versionToString(version)} to ${versionToString(newVersion)}`);
+  await PackageJson.writePackageJsonFileWithNewVersion(pj, newVersion, pjFile);
+};
+
+export const advancePatch = async (version: Version, pj: PackageJson, pjFile: string, git: SimpleGit): Promise<void> => {
+  await advance(version, pj, pjFile, updateToNextPatch);
+  await git.add(pjFile);
+  await git.commit('Update version for next patch release');
+};
+
+export const advanceMinor = async (version: Version, pj: PackageJson, pjFile: string, git: SimpleGit): Promise<void> => {
+  await advance(version, pj, pjFile, updateToNextMinor);
+  await git.add(pjFile);
+  await git.commit(`Update version for next minor release`);
+};

--- a/src/main/ts/core/BranchLogic.ts
+++ b/src/main/ts/core/BranchLogic.ts
@@ -1,10 +1,11 @@
 import * as path from 'path';
 import * as O from 'fp-ts/Option';
 import * as gitP from 'simple-git/promise';
-import { CheckRepoActions } from 'simple-git';
+import { CheckRepoActions, SimpleGit } from 'simple-git';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { showStringOrUndefined } from '../utils/StringUtils';
 import * as Git from '../utils/Git';
+import { writeBuildPropertiesFile } from './BuildProperties';
 import * as Version from './Version';
 import * as PreRelease from './PreRelease';
 import * as PackageJson from './PackageJson';
@@ -201,3 +202,10 @@ export const getBranchDetails = async (dir: string): Promise<BranchDetails> => {
   }
 };
 
+export const createReleaseBranch = async (releaseBranchName: string, git: SimpleGit, dir: string): Promise<void> => {
+  console.log(`Creating ${releaseBranchName} branch`);
+  await Git.checkoutNewBranch(git, releaseBranchName);
+  const buildPropertiesFile = await writeBuildPropertiesFile(dir, releaseBranchName);
+  await git.add([ buildPropertiesFile ]);
+  await git.commit(`Creating release branch: ${releaseBranchName}`);
+};

--- a/src/main/ts/core/BuildProperties.ts
+++ b/src/main/ts/core/BuildProperties.ts
@@ -1,0 +1,17 @@
+import * as path from 'path';
+import * as PropertiesReader from 'properties-reader';
+import * as Files from '../utils/Files';
+
+export const writeBuildPropertiesFile = async (dir: string, releaseBranchName: string): Promise<string> => {
+  const buildPropertiesFile = path.resolve(dir, 'build.properties');
+  if (!await Files.exists(buildPropertiesFile)) {
+    console.log(`${buildPropertiesFile} does not exist: creating`);
+    await Files.writeFile(buildPropertiesFile, '');
+  }
+
+  console.log(`Updating properties file: ${buildPropertiesFile}`);
+  const props = PropertiesReader(buildPropertiesFile);
+  props.set('primaryBranch', releaseBranchName);
+  await props.save(buildPropertiesFile);
+  return buildPropertiesFile;
+};

--- a/src/main/ts/utils/Git.ts
+++ b/src/main/ts/utils/Git.ts
@@ -117,3 +117,8 @@ const detectGitUrlFromDir = async (dir: string): Promise<string> => {
 
 export const resolveGitUrl = async (gitUrlArg: Option<string>, workingDirArg: string): Promise<string> =>
   O.isSome(gitUrlArg) ? gitUrlArg.value : await detectGitUrlFromDir(workingDirArg);
+
+export const getTags = async (g: SimpleGit): Promise<string[]> => {
+  const tags = await g.tags();
+  return tags.all;
+};

--- a/src/main/ts/utils/OptionUtils.ts
+++ b/src/main/ts/utils/OptionUtils.ts
@@ -1,3 +1,5 @@
+import * as Arr from 'fp-ts/Array';
+import { identity, pipe } from 'fp-ts/function';
 import * as O from 'fp-ts/Option';
 
 type Option<A> = O.Option<A>;
@@ -11,12 +13,5 @@ export const eachAsync = async <A> (o: Option<A>, f: (a: A) => Promise<void>): P
 export const mapAsync = async <A, B> (o: Option<A>, f: (a: A) => Promise<B>): Promise<Option<B>> =>
   O.isSome(o) ? O.some(await f(o.value)) : O.none;
 
-export const somes = <A> (options: Array<Option<A>>): Array<A> => {
-  const r: A[] = [];
-  for (const o of options) {
-    if (O.isSome(o)) {
-      r.push(o.value);
-    }
-  }
-  return r;
-};
+export const somes = <A> (options: Array<Option<A>>): Array<A> =>
+  pipe(options, Arr.filterMap(identity));

--- a/src/main/ts/utils/OptionUtils.ts
+++ b/src/main/ts/utils/OptionUtils.ts
@@ -10,3 +10,13 @@ export const eachAsync = async <A> (o: Option<A>, f: (a: A) => Promise<void>): P
 
 export const mapAsync = async <A, B> (o: Option<A>, f: (a: A) => Promise<B>): Promise<Option<B>> =>
   O.isSome(o) ? O.some(await f(o.value)) : O.none;
+
+export const somes = <A> (options: Array<Option<A>>): Array<A> => {
+  const r: A[] = [];
+  for (const o of options) {
+    if (O.isSome(o)) {
+      r.push(o.value);
+    }
+  }
+  return r;
+};

--- a/src/test/ts/commands/AdvanceTest.ts
+++ b/src/test/ts/commands/AdvanceTest.ts
@@ -1,27 +1,14 @@
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
-import * as Advance from '../../../main/ts/commands/Advance';
-import * as Version from '../../../main/ts/core/Version';
 import * as Git from '../../../main/ts/utils/Git';
 import { makeBranchWithPj, beehiveFlow, readPjVersionInDir } from './TestUtils';
 
 describe('Advance', () => {
-  describe('updateVersion', () => {
-    it('Updates versions', async () => {
-      const check = async (input: string, expected: string) => {
-        assert.equal(Version.versionToString(Advance.updateVersion(await Version.parseVersion(input))), expected);
-      };
-      await check('0.0.0', '0.0.1-rc');
-      await check('1.0.0', '1.0.1-rc');
-      await check('0.300.100', '0.300.101-rc');
-    });
-  });
-
   describe('advance', () => {
     const runScenario = async (branchName: string, version: string, arg: string) => {
       const hub = await Git.initInTempFolder(true);
       const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-advance', version);
+      await makeBranchWithPj(git, branchName, dir, 'test-advance', version);
       await beehiveFlow([ 'advance', arg, '--working-dir', dir ]);
       await git.pull();
       return dir;
@@ -42,7 +29,7 @@ describe('Advance', () => {
     const runScenario = async (branchName: string, version: string) => {
       const hub = await Git.initInTempFolder(true);
       const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-advance', version);
+      await makeBranchWithPj(git, branchName, dir, 'test-advance', version);
       await beehiveFlow([ 'advance-ci', '--working-dir', dir ]);
       await git.pull();
       return dir;

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -1,13 +1,11 @@
-import * as path from 'path';
 import { describe, it } from 'mocha';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as O from 'fp-ts/Option';
 import * as Git from '../../../main/ts/utils/Git';
-import * as Files from '../../../main/ts/utils/Files';
 import * as PackageJson from '../../../main/ts/core/PackageJson';
 import * as Version from '../../../main/ts/core/Version';
-import { beehiveFlow } from './TestUtils';
+import { beehiveFlow, makeBranchWithPj } from './TestUtils';
 
 const assert = chai.use(chaiAsPromised).assert;
 
@@ -16,17 +14,7 @@ describe('Lifecycle', () => {
     const hub = await Git.initInTempFolder(true);
 
     const { dir, git } = await Git.cloneInTempFolder(hub.dir, O.none);
-    await Git.checkoutNewBranch(git, 'main');
-    await Files.writeFile(path.join(dir, 'package.json'), `
-    {
-      "name": "@beehive-test/lifecycle-test",
-      "version": "0.1.0-rc"
-    }
-    `);
-
-    await git.add('package.json');
-    await git.commit('Initial');
-    await Git.push(git);
+    await makeBranchWithPj(git, 'main', dir, 'lifecycle-test', '0.1.0-rc');
 
     const assertPjVersion = async (expected: string) => {
       const pj = await PackageJson.parsePackageJsonFileInFolder(dir);

--- a/src/test/ts/commands/PrepareTest.ts
+++ b/src/test/ts/commands/PrepareTest.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import { versionFromReleaseBranch } from '../../../main/ts/core/BranchLogic';
+import { versionToString } from '../../../main/ts/core/Version';
+import * as Git from '../../../main/ts/utils/Git';
+import { beehiveFlow, makeBranchWithPj, readPjVersionInDir } from './TestUtils';
+
+describe('Prepare', () => {
+  const runScenario = async (version: string, branches: string[] = []) => {
+    const hub = await Git.initInTempFolder(true);
+    const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+
+    const packageName = 'test-prepare';
+    await makeBranchWithPj(git, 'main', dir, packageName, version);
+    for (const branch of branches) {
+      const releaseVersion = await versionFromReleaseBranch(branch);
+      await makeBranchWithPj(git, branch, dir, packageName, versionToString({ patch: 0, ...releaseVersion }));
+    }
+
+    await beehiveFlow([ 'prepare', '--working-dir', dir ]);
+    await git.pull();
+    return { git, dir };
+  };
+
+  it('retains the current patch version in the release branch', async () => {
+    const { git, dir } = await runScenario( '1.1.2-rc');
+    await assert.becomes(readPjVersionInDir(dir), '1.2.0-rc');
+    await git.checkout('release/1.1');
+    await assert.becomes(readPjVersionInDir(dir), '1.1.2-rc');
+  });
+
+  it('fails if the main branch is not an RC version', async () => {
+    const result = runScenario('0.1.0');
+    await assert.isRejected(result, 'main branch should have an rc version when running this command');
+  });
+
+  it('fails if a release branch already exists', async () => {
+    const result = runScenario('0.1.0-rc', [ 'release/0.1' ]);
+    await assert.isRejected(result, 'Remote branch already exists: release/0.1');
+  });
+});

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -65,11 +65,11 @@ describe('Publish', () => {
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
 
     // publish a dummy version, so we have something as "latest"
-    await makeBranchWithPj(git, 'feature/dummy', address, dir, packageName, '0.0.1-rc');
+    await makeBranchWithPj(git, 'feature/dummy', dir, packageName, '0.0.1-rc', address);
     await publish(dryRun, dir);
 
     // publish the version we care about
-    const pjFile = await makeBranchWithPj(git, branchName, address, dir, packageName, version);
+    const pjFile = await makeBranchWithPj(git, branchName, dir, packageName, version, address);
     await stamp(dir);
     const stampedVersion = await readPjVersion(pjFile);
     await publish(dryRun, dir);

--- a/src/test/ts/commands/ReleaseTest.ts
+++ b/src/test/ts/commands/ReleaseTest.ts
@@ -1,40 +1,25 @@
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
-import * as Release from '../../../main/ts/commands/Release';
-import * as Version from '../../../main/ts/core/Version';
 import * as Git from '../../../main/ts/utils/Git';
 import { beehiveFlow, makeBranchWithPj, readPjVersionInDir } from './TestUtils';
 
 describe('Release', () => {
-  describe('updateVersion', () => {
-    it('Updates versions', async () => {
-      const check = async (input: string, expected: string) => {
-        assert.equal(Version.versionToString(Release.updateVersion(await Version.parseVersion(input))), expected);
-      };
-      await check('0.0.0-rc', '0.0.0');
-      await check('1.0.0-rc', '1.0.0');
-      await check('0.300.100-rc', '0.300.100');
-    });
+  const runScenario = async (branchName: string, version: string, arg: string) => {
+    const hub = await Git.initInTempFolder(true);
+    const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+    await makeBranchWithPj(git, branchName, dir, 'test-release', version);
+    await beehiveFlow([ 'release', arg, '--working-dir', dir ]);
+    await git.pull();
+    return dir;
+  };
+
+  it('releases rc version from main', async () => {
+    const dir = await runScenario('main', '0.0.1-rc', 'main');
+    await assert.becomes(readPjVersionInDir(dir), '0.0.1');
   });
 
-  describe('release', () => {
-    const runScenario = async (branchName: string, version: string, arg: string) => {
-      const hub = await Git.initInTempFolder(true);
-      const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-      await makeBranchWithPj(git, branchName, 'blah://frog', dir, 'test-release', version);
-      await beehiveFlow([ 'release', arg, '--working-dir', dir ]);
-      await git.pull();
-      return dir;
-    };
-
-    it('releases rc version from main', async () => {
-      const dir = await runScenario('main', '0.0.1-rc', 'main');
-      await assert.becomes(readPjVersionInDir(dir), '0.0.1');
-    });
-
-    it('releases rc version from release branch', async () => {
-      const dir = await runScenario('release/88.1', '88.1.9-rc', '88.1');
-      await assert.becomes(readPjVersionInDir(dir), '88.1.9');
-    });
+  it('releases rc version from release branch', async () => {
+    const dir = await runScenario('release/88.1', '88.1.9-rc', '88.1');
+    await assert.becomes(readPjVersionInDir(dir), '88.1.9');
   });
 });

--- a/src/test/ts/commands/ReviveTest.ts
+++ b/src/test/ts/commands/ReviveTest.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import { versionFromReleaseBranch } from '../../../main/ts/core/BranchLogic';
+import { versionToString } from '../../../main/ts/core/Version';
+import * as Git from '../../../main/ts/utils/Git';
+import { beehiveFlow, makeBranchWithPj, makeReleaseTags, readPjVersionInDir } from './TestUtils';
+
+describe('Revive', () => {
+  const runScenario = async (tags: string[], branches: string[], arg: string) => {
+    const hub = await Git.initInTempFolder(true);
+    const { dir, git } = await Git.cloneInTempFolder(hub.dir);
+
+    const packageName = 'test-revive';
+    await makeBranchWithPj(git, 'main', dir, packageName, '0.1.1-rc');
+    await makeReleaseTags(git, dir, packageName, tags);
+    for (const branch of branches) {
+      const version = await versionFromReleaseBranch(branch);
+      await makeBranchWithPj(git, branch, dir, packageName, versionToString({ patch: 0, ...version }));
+    }
+
+    await beehiveFlow([ 'revive', arg, '--working-dir', dir ]);
+    await git.pull();
+    await git.checkout(`release/${arg}`);
+    return { git, dir };
+  };
+
+  it('revives version from 1.0.0 tag', async () => {
+    const { git, dir } = await runScenario([ '0.1.0', '1.0.0' ], [], '1.0');
+    await assert.becomes(Git.currentBranch(git), 'release/1.0');
+    await assert.becomes(readPjVersionInDir(dir), '1.0.1-rc');
+  });
+
+  it('revives version when multiple tags exist', async () => {
+    const { git, dir } = await runScenario([ '0.1.0', '1.0.0', '1.1.0', '1.1.1', '1.1.2' ], [ 'release/1.0' ], '1.1');
+    await assert.becomes(Git.currentBranch(git), 'release/1.1');
+    await assert.becomes(readPjVersionInDir(dir), '1.1.3-rc');
+  });
+
+  it('fails if a release branch already exists', async () => {
+    const result = runScenario([ '1.0.0' ], [ 'release/1.0' ], '1.0');
+    await assert.isRejected(result, 'Remote branch already exists: release/1.0');
+  });
+
+  it('fails if main is at the same major.minor version', async () => {
+    const result = runScenario([ '0.0.1' ], [], '0.1');
+    await assert.isRejected(result, 'main branch is still at version: 0.1');
+  });
+
+  it('fails if no tags exist for the specified major.major version', async () => {
+    const result = runScenario([ '0.0.1' ], [], '1.0');
+    await assert.isRejected(result, 'Failed to find any tags matching version: 1.0');
+  });
+});

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -1,18 +1,16 @@
 import * as path from 'path';
 import * as O from 'fp-ts/Option';
-import { SimpleGit } from 'simple-git/promise';
-import * as Git from '../../../main/ts/utils/Git';
-import * as Files from '../../../main/ts/utils/Files';
-import * as Parser from '../../../main/ts/args/Parser';
+import { SimpleGit } from 'simple-git';
 import * as Dispatch from '../../../main/ts/args/Dispatch';
+import * as Parser from '../../../main/ts/args/Parser';
+import * as NpmTags from '../../../main/ts/core/NpmTags';
 import * as PackageJson from '../../../main/ts/core/PackageJson';
 import { versionToString } from '../../../main/ts/core/Version';
-import * as NpmTags from '../../../main/ts/core/NpmTags';
+import * as Files from '../../../main/ts/utils/Files';
+import * as Git from '../../../main/ts/utils/Git';
 import * as ObjUtils from '../../../main/ts/utils/ObjUtils';
 
-export const makeBranchWithPj = async (git: SimpleGit, branchName: string, address: string, dir: string, packageName: string, version: string) => {
-  await Git.checkoutNewBranch(git, branchName);
-  const npmrcFile = await writeNpmrc(address, dir);
+const writePackageJson = async (dir: string, packageName: string, version: string, address: string = 'blah://frog') => {
   const pjFile = path.join(dir, 'package.json');
   const pjContents = `
       {
@@ -23,9 +21,6 @@ export const makeBranchWithPj = async (git: SimpleGit, branchName: string, addre
         }
       }`;
   await Files.writeFile(pjFile, pjContents);
-  await git.add([ npmrcFile, pjFile ]);
-  await git.commit('commit');
-  await Git.push(git);
   return pjFile;
 };
 
@@ -34,6 +29,23 @@ export const writeNpmrc = async (address: string, dir: string): Promise<string> 
   const npmrcFile = path.join(dir, '.npmrc');
   await Files.writeFile(npmrcFile, npmrc);
   return npmrcFile;
+};
+
+export const makeBranchWithPj = async (
+  git: SimpleGit,
+  branchName: string,
+  dir: string,
+  packageName: string,
+  version: string,
+  address: string = 'blah://frog'
+) => {
+  await Git.checkoutNewBranch(git, branchName);
+  const npmrcFile = await writeNpmrc(address, dir);
+  const pjFile = await writePackageJson(dir, packageName, version, address);
+  await git.add([ npmrcFile, pjFile ]);
+  await git.commit('commit');
+  await Git.push(git);
+  return pjFile;
 };
 
 export const beehiveFlow = async (args: string[]): Promise<void> => {
@@ -61,3 +73,18 @@ export const readPjVersion = async (pjFile: string): Promise<string> => {
 
 export const readPjVersionInDir = async (dir: string): Promise<string> =>
   readPjVersion(path.join(dir, 'package.json'));
+
+export const makeReleaseTags = async (git: SimpleGit, dir: string, packageName: string, tags: string[]): Promise<void> => {
+  await Git.checkoutMainBranch(git);
+  const tempBranchName = 'temp';
+  await Git.checkoutNewBranch(git, tempBranchName);
+  for (const tag of tags) {
+    const pjFile = await writePackageJson(dir, packageName, tag);
+    await git.add([ pjFile ]);
+    await git.commit(`Release ${tag}`);
+    await git.addTag(tag);
+  }
+  await Git.checkoutMainBranch(git);
+  await git.deleteLocalBranch(tempBranchName, true);
+  await git.push([ '--tags' ]);
+};

--- a/src/test/ts/core/AdvanceVersionTest.ts
+++ b/src/test/ts/core/AdvanceVersionTest.ts
@@ -1,0 +1,43 @@
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import * as AdvanceVersion from '../../../main/ts/core/AdvanceVersion';
+import * as Version from '../../../main/ts/core/Version';
+
+describe('AdvanceVersion', () => {
+  describe('updateToNextPatch', () => {
+    it('Updates version to next RC patch version', async () => {
+      const check = async (input: string, expected: string) => {
+        const newVersion = AdvanceVersion.updateToNextPatch(await Version.parseVersion(input));
+        assert.equal(Version.versionToString(newVersion), expected);
+      };
+      await check('0.0.0', '0.0.1-rc');
+      await check('1.0.0', '1.0.1-rc');
+      await check('0.300.100', '0.300.101-rc');
+    });
+  });
+
+  describe('updateToNextMinor', () => {
+    it('Updates version to next RC minor version', async () => {
+      const check = async (input: string, expected: string) => {
+        const newVersion = AdvanceVersion.updateToNextMinor(await Version.parseVersion(input));
+        assert.equal(Version.versionToString(newVersion), expected);
+      };
+      await check('0.0.0', '0.1.0-rc');
+      await check('1.0.0', '1.1.0-rc');
+      await check('0.300.100', '0.301.0-rc');
+      await check('1.0.5-rc', '1.1.0-rc');
+    });
+  });
+
+  describe('updateToStable', () => {
+    it('Updates versions from RC to stable', async () => {
+      const check = async (input: string, expected: string) => {
+        const newVersion = AdvanceVersion.updateToStable(await Version.parseVersion(input));
+        assert.equal(Version.versionToString(newVersion), expected);
+      };
+      await check('0.0.0-rc', '0.0.0');
+      await check('1.0.0-rc', '1.0.0');
+      await check('0.300.100-rc', '0.300.100');
+    });
+  });
+});

--- a/src/test/ts/utils/OptionUtilsTest.ts
+++ b/src/test/ts/utils/OptionUtilsTest.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import fc from 'fast-check';
+import * as O from 'fp-ts/Option';
+import * as OptionUtils from '../../../main/ts/utils/OptionUtils';
+
+describe('OptionUtils', () => {
+  describe('somes', () => {
+    it('is identity when all elements are some', () => {
+      fc.assert(fc.property(fc.array(fc.integer()), (xs) => {
+        assert.deepEqual(
+          OptionUtils.somes(xs.map(O.some)),
+          xs
+        );
+      }));
+    });
+
+    it('returns empty array when all elements are none', () => {
+      fc.assert(fc.property(fc.array(fc.integer()), (xs) => {
+        assert.deepEqual(
+          OptionUtils.somes(xs.map(() => O.none)),
+          []
+        );
+      }));
+    });
+
+    it('gets the somes', () => {
+      assert.deepEqual(
+        OptionUtils.somes([ O.none, O.some(1), O.some(2), O.none, O.some(7) ]),
+        [ 1, 2, 7 ]
+      );
+    });
+  });
+});


### PR DESCRIPTION
Description of changes:
* Added a new `revive` command to recreate a release branch from previous release tags.
  * This command will also check to make sure we're not trying to create a release for the version already on `main` and that a `release/x.y` branch doesn't already exist. 
* Restructured some of the advance version logic so it's all in one place (this as needed for the new command).
* Fixed the `prepare` command incorrectly reseting the patch version back to 0 (this was just a side-effect of the above restructure).