### PR TITLE
TINY-7502: Don't allow releases to succeed if the package has pre-release dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improved
 - An error will be thrown when attempting to `release` from a repository with un-pushed local changes. #TINY-7407
-- The `release` command will now fail if the package still contains pre-release dependencies. #TINY-7502
+- The `release` command will now fail if the package still contains pre-release dependencies. This can be disabled using the `--allow-pre-releases` option. #TINY-7502
 
 ### Fixed
  - The `prepare` command would incorrectly reset the release branch patch version back to 0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improved
 - An error will be thrown when attempting to `release` from a repository with un-pushed local changes. #TINY-7407
+- The `release` command will now fail if the package still contains pre-release dependencies. #TINY-7502
 
 ### Fixed
  - The `prepare` command would incorrectly reset the release branch patch version back to 0.

--- a/src/main/ts/args/BeehiveArgs.ts
+++ b/src/main/ts/args/BeehiveArgs.ts
@@ -16,6 +16,7 @@ export interface ReleaseArgs extends BaseArgs {
   readonly temp: Option<string>;
   readonly branchName: string;
   readonly gitUrl: Option<string>;
+  readonly allowPreReleaseDeps: boolean;
 }
 
 export interface AdvanceArgs extends BaseArgs {
@@ -58,14 +59,15 @@ export const prepareArgs = (dryRun: boolean, workingDir: string, temp: Option<st
 });
 
 export const releaseArgs = (
-  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string
+  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string, allowPreReleaseDeps: boolean
 ): ReleaseArgs => ({
   kind: 'ReleaseArgs',
   dryRun,
   workingDir,
   temp,
   gitUrl,
-  branchName
+  branchName,
+  allowPreReleaseDeps
 });
 
 export const advanceArgs = (

--- a/src/main/ts/args/Parser.ts
+++ b/src/main/ts/args/Parser.ts
@@ -53,6 +53,12 @@ const distDirOptions: yargs.Options = {
     'The package.json file in this dir must have the same name and version as the one in the working-dir.'
 };
 
+const allowPreReleaseDepsOptions: yargs.Options = {
+  description: 'Allow pre-release dependencies when releasing.',
+  type: 'boolean',
+  default: false
+};
+
 const getColumns = (): number =>
   Math.min(120, yargs.terminalWidth());
 
@@ -83,6 +89,7 @@ const argParser =
         .positional('majorMinorOrMain', majorMinorOrMainOptions)
         .option('git-url', gitUrlOptions)
         .option('temp', tempOptions)
+        .option('allow-pre-releases', allowPreReleaseDepsOptions)
     )
     .command(
       'advance <majorMinorOrMain>',
@@ -172,7 +179,7 @@ export const parseArgs = async (args: string[]): Promise<Option<BeehiveArgs>> =>
     return O.some(BeehiveArgs.prepareArgs(dryRun, workingDir, temp(), gitUrl()));
 
   } else if (cmd === 'release') {
-    return O.some(BeehiveArgs.releaseArgs(dryRun, workingDir, temp(), gitUrl(), await majorMinorOrMain()));
+    return O.some(BeehiveArgs.releaseArgs(dryRun, workingDir, temp(), gitUrl(), await majorMinorOrMain(), a['allow-pre-releases'] as boolean));
 
   } else if (cmd === 'advance') {
     return O.some(BeehiveArgs.advanceArgs(dryRun, workingDir, temp(), gitUrl(), await majorMinorOrMain()));

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -1,15 +1,12 @@
 import * as O from 'fp-ts/Option';
 import { ReleaseArgs } from '../args/BeehiveArgs';
-import * as Version from '../core/Version';
+import { versionToString } from '../core/Version';
 import * as Git from '../utils/Git';
 import * as AdvanceVersion from '../core/AdvanceVersion';
 import * as PackageJson from '../core/PackageJson';
 import * as PromiseUtils from '../utils/PromiseUtils';
 import { BranchState, getBranchDetails } from '../core/BranchLogic';
 import { printHeaderMessage } from '../core/Messages';
-
-type Version = Version.Version;
-const { versionToString } = Version;
 
 export const release = async (args: ReleaseArgs): Promise<void> => {
   printHeaderMessage(args);
@@ -33,10 +30,13 @@ export const release = async (args: ReleaseArgs): Promise<void> => {
     return PromiseUtils.fail('Branch is not in Release Candidate state - can\'t release.');
   }
 
+  const rootModule = branchDetails.rootModule;
+  if (!args.allowPreReleaseDeps) {
+    await PackageJson.shouldNotHavePreReleasePackages(rootModule.packageJson);
+  }
+
   const newVersion = AdvanceVersion.updateToStable(branchDetails.version);
   console.log(`Updating version from ${versionToString(branchDetails.version)} to ${versionToString(newVersion)}`);
-
-  const rootModule = branchDetails.rootModule;
   await PackageJson.writePackageJsonFileWithNewVersion(rootModule.packageJson, newVersion, rootModule.packageJsonFile);
 
   await git.add(rootModule.packageJsonFile);

--- a/src/main/ts/utils/ObjUtils.ts
+++ b/src/main/ts/utils/ObjUtils.ts
@@ -5,7 +5,7 @@ type Option<A> = O.Option<A>;
 export const hasKey = <T>(o: T, k: keyof T): boolean =>
   Object.prototype.hasOwnProperty.call(o, k);
 
-export const lookup = <T>(o: T, k: keyof T): Option<T[keyof T]> =>
+export const lookup = <K extends keyof T, T>(o: T, k: K): Option<T[K]> =>
   hasKey(o, k) ? O.some(o[k]) : O.none;
 
 export const map = <A, B>(o: Record<string, A>, f: (a: A) => B): Record<string, B> => {

--- a/src/test/ts/args/ParserTest.ts
+++ b/src/test/ts/args/ParserTest.ts
@@ -30,11 +30,11 @@ describe('Parser', () => {
       await fc.assert(fc.asyncProperty(fc.nat(100), fc.nat(100), async (major, minor) => {
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}` ]),
-          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
+          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false))
         );
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}`, '--dry-run' ]),
-          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`))
+          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false))
         );
       }));
     });
@@ -42,7 +42,7 @@ describe('Parser', () => {
     it('succeeds for release command with main arg', async () => {
       await assert.becomes(
         parseArgs([ 'release', 'main' ]),
-        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main'))
+        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main', false))
       );
     });
 

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -65,11 +65,11 @@ describe('Publish', () => {
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
 
     // publish a dummy version, so we have something as "latest"
-    await makeBranchWithPj(git, 'feature/dummy', dir, packageName, '0.0.1-rc', address);
+    await makeBranchWithPj(git, 'feature/dummy', dir, packageName, '0.0.1-rc', {}, address);
     await publish(dryRun, dir);
 
     // publish the version we care about
-    const pjFile = await makeBranchWithPj(git, branchName, dir, packageName, version, address);
+    const pjFile = await makeBranchWithPj(git, branchName, dir, packageName, version, {}, address);
     await stamp(dir);
     const stampedVersion = await readPjVersion(pjFile);
     await publish(dryRun, dir);

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -10,7 +10,9 @@ import * as Files from '../../../main/ts/utils/Files';
 import * as Git from '../../../main/ts/utils/Git';
 import * as ObjUtils from '../../../main/ts/utils/ObjUtils';
 
-const writePackageJson = async (dir: string, packageName: string, version: string, address: string = 'blah://frog') => {
+const writePackageJson = async (
+  dir: string, packageName: string, version: string, dependencies: Record<string, string> = {}, address: string = 'blah://frog'
+) => {
   const pjFile = path.join(dir, 'package.json');
   const pjContents = `
       {
@@ -18,7 +20,8 @@ const writePackageJson = async (dir: string, packageName: string, version: strin
         "version": "${version}",
         "publishConfig": {
           "@beehive-test:registry": "${address}"
-        }
+        },
+        "dependencies": ${JSON.stringify(dependencies)}
       }`;
   await Files.writeFile(pjFile, pjContents);
   return pjFile;
@@ -44,11 +47,12 @@ export const makeBranchWithPj = async (
   dir: string,
   packageName: string,
   version: string,
+  dependencies: Record<string, string> = {},
   address: string = 'blah://frog'
 ) => {
   await Git.checkoutNewBranch(git, branchName);
   const npmrcFile = await writeNpmrc(address, dir);
-  const pjFile = await writePackageJson(dir, packageName, version, address);
+  const pjFile = await writePackageJson(dir, packageName, version, dependencies, address);
   await git.add([ npmrcFile, pjFile ]);
   await git.commit('commit');
   await Git.push(git);

--- a/src/test/ts/core/PackageJsonTest.ts
+++ b/src/test/ts/core/PackageJsonTest.ts
@@ -54,7 +54,7 @@ describe('PackageJson', () => {
       }));
     });
 
-    it('decodes beehive-flow custom properies', () => {
+    it('decodes beehive-flow custom properties', () => {
       const actual = PackageJson.decodeE({
         name: 'blah',
         version: '1.2.3-rc',
@@ -67,6 +67,29 @@ describe('PackageJson', () => {
         version: { major: 1, minor: 2, patch: 3, preRelease: 'rc', buildMetaData: undefined },
         beehiveFlow: {
           primaryWorkspace: 'blah'
+        }
+      }));
+    });
+
+    it('decodes dependencies', () => {
+      const actual = PackageJson.decodeE({
+        name: 'blah',
+        version: '1.2.3-rc',
+        devDependencies: {
+          '@tinymce/beehive-flow': 'latest'
+        },
+        dependencies: {
+          dep1: '>=5.0.0'
+        }
+      });
+      assert.deepEqual(actual, E.right({
+        name: 'blah',
+        version: { major: 1, minor: 2, patch: 3, preRelease: 'rc', buildMetaData: undefined },
+        devDependencies: {
+          '@tinymce/beehive-flow': 'latest'
+        },
+        dependencies: {
+          dep1: '>=5.0.0'
         }
       }));
     });
@@ -83,6 +106,48 @@ describe('PackageJson', () => {
       const parsed = await PackageJson.decode(input);
       const output = PackageJson.toJson(parsed);
       assert.deepEqual(output, input);
+    });
+  });
+
+  describe('check pre-release dependencies', () => {
+    it('should fail when a dependency is a pre-release version', async () => {
+      const pj = {
+        name: 'blah',
+        dependencies: {
+          dep1: '^5.0.0-rc',
+          dep2: '^5.0.0-feature.20210525.sha123456',
+          dep3: '^5.0.0-spike.20210525.shaabcdef',
+          dep4: '^5.0.0-hotfix.20210525.sha123abc',
+          beehive: '^0.16.0'
+        }
+      };
+      const result = PackageJson.shouldNotHavePreReleasePackages(pj);
+      await assert.isRejected(result, 'Pre-release versions were found for: dep1, dep2, dep3, dep4');
+    });
+
+    it('should fail when the beehive dev dependency is a pre-release version', async () => {
+      const pj = {
+        name: 'blah',
+        devDependencies: {
+          '@tinymce/beehive-flow': '^0.16.0-rc'
+        }
+      };
+      const result = PackageJson.shouldNotHavePreReleasePackages(pj);
+      await assert.isRejected(result, 'Pre-release versions were found for: @tinymce/beehive-flow');
+    });
+
+    it('should ignore RC dev dependencies', async () => {
+      const pj = {
+        name: 'blah',
+        devDependencies: {
+          dep1: '^5.0.0-rc',
+          dep2: '^5.0.0-feature.20210525.sha123456',
+          dep3: '^5.0.0-spike.20210525.shaabcdef',
+          dep4: '^5.0.0-hotfix.20210525.sha123abc'
+        }
+      };
+      const result = PackageJson.shouldNotHavePreReleasePackages(pj);
+      await assert.isFulfilled(result);
     });
   });
 });


### PR DESCRIPTION
Description of changes:
- Updated the `release` command to validate that there are no pre-release dependencies. I've also added a new `--allow-pre-releases` option in case we have a use case where we would want to allow that.