### PR TITLE
TINY-7165: Added support for dependabot branch prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
  - `beehive-flow revive a.b` command to recreate a release branch from tags. #TINY-7474
+ - Support `dependabot` branch prefixes. #TINY-7165
 
 ### Improved
 - An error will be thrown when attempting to `release` from a repository with un-pushed local changes. #TINY-7407

--- a/src/main/ts/core/BranchLogic.ts
+++ b/src/main/ts/core/BranchLogic.ts
@@ -25,7 +25,8 @@ export const enum BranchType {
   Feature = 'feature',
   Hotfix = 'hotfix',
   Spike = 'spike',
-  Release = 'release'
+  Release = 'release',
+  Dependabot = 'dependabot'
 }
 
 // eslint-disable-next-line no-shadow
@@ -81,6 +82,8 @@ export const getBranchType = (branchName: string): Option<BranchType> => {
         return O.some(BranchType.Spike);
       case 'release':
         return O.some(BranchType.Release);
+      case 'dependabot':
+        return O.some(BranchType.Dependabot);
       default:
         return O.none;
     }
@@ -172,6 +175,7 @@ export const getBranchDetails = async (dir: string): Promise<BranchDetails> => {
       case BranchType.Main:
         return validateMainBranch();
       case BranchType.Feature:
+      case BranchType.Dependabot:
         return BranchState.Feature;
       case BranchType.Hotfix:
         return BranchState.Hotfix;

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -23,7 +23,7 @@ export const pickTags = async (
 ): Promise<[ string, ...string[] ]> => {
 
   const branchTag = branchName
-    .replace('/npm_and_yarn/', '/') // Strip dependabot secondary prefix
+    .replace(/dependabot\/[^\/]+\//, 'dependabot/') // Strip dependabot secondary/ecosystem component
     .replace(/[^\w.]+/g, '-');
 
   const vs = majorMinorVersionToString(version);

--- a/src/main/ts/core/NpmTags.ts
+++ b/src/main/ts/core/NpmTags.ts
@@ -22,7 +22,9 @@ export const pickTags = async (
   branchName: string, branchState: BranchState, version: Version, npmTags: () => Promise<NpmTags>
 ): Promise<[ string, ...string[] ]> => {
 
-  const branchTag = branchName.replace(/[^\w.]+/g, '-');
+  const branchTag = branchName
+    .replace('/npm_and_yarn/', '/') // Strip dependabot secondary prefix
+    .replace(/[^\w.]+/g, '-');
 
   const vs = majorMinorVersionToString(version);
 

--- a/src/test/ts/core/BranchLogicTest.ts
+++ b/src/test/ts/core/BranchLogicTest.ts
@@ -134,6 +134,10 @@ describe('BranchLogic', () => {
       check('feature/BLAH-1234', '0.6.0-alpha', BranchType.Feature, BranchState.Feature)
     );
 
+    it('detects valid dependabot branch', () =>
+      check('dependabot/npm_and_yarn/package-1.0.0', '0.6.0-alpha', BranchType.Dependabot, BranchState.Feature)
+    );
+
     it('detects valid spike branch', () =>
       check('spike/BLAH-1234', '0.6.0-alpha', BranchType.Spike, BranchState.Spike)
     );

--- a/src/test/ts/core/NpmTagsTest.ts
+++ b/src/test/ts/core/NpmTagsTest.ts
@@ -253,13 +253,13 @@ describe('NpmTags', () => {
       const specialChar = () => fc.char().filter((char) => !/[\w.]/.test(char));
       const alphanumeric = () => fc.char().filter((char) => /\w/.test(char));
 
-      it('arbitrary branch names should collapse special characters', () =>
+      it('should collapse special characters', () =>
         fc.assert(fc.asyncProperty(fc.stringOf(alphanumeric(), { minLength: 1 }), fc.stringOf(specialChar(), { minLength: 1 }), (str, special) =>
           checkSimple(`${str}${special}${str}`, BranchState.Spike, '0.1.5', [ `${str}-${str}` ])
         ))
       );
 
-      it('arbitrary dependabot prefixed branch names', () =>
+      it('handles dependabot prefixed branch names', () =>
         fc.assert(fc.asyncProperty(fc.stringOf(alphanumeric(), { minLength: 1 }), fc.lorem(), (str, lorem) =>
           checkSimple(`dependabot/${str}/${lorem}`, BranchState.Feature, '1.5.2', [ `dependabot-${lorem.replace(/ /g, '-')}` ])
         ))

--- a/src/test/ts/core/NpmTagsTest.ts
+++ b/src/test/ts/core/NpmTagsTest.ts
@@ -32,7 +32,12 @@ describe('NpmTags', () => {
       it('replaces multiple slashes', () =>
         checkSimple('feature/BLAH/12/3', BranchState.Feature, '100.7.22', [ 'feature-BLAH-12-3' ])
       );
+    });
 
+    describe('dependabot branches', () => {
+      it('uses the branch name without npm_and_yarn component', () =>
+        checkSimple('dependabot/npm_and_yarn/package-1.0.0', BranchState.Feature, '0.1.0', [ 'dependabot-package-1.0.0' ])
+      );
     });
 
     describe('spike branches', () => {


### PR DESCRIPTION
Description of changes:

Added support for `dependabot` branch prefixes. These branches are treated as being in a "feature" state, so that's what's used in the version number. It'll also use `dependabot-` as the prefix for the npm tag, excluding the `npm_and_yarn` component (eg: `dependabot-hosted-git-info-2.8.9`).

Note: We'll still need to decided if we want dependabot packages published. If we don't, that'd be better handled in our Jenkinsfile scripts.