### PR TITLE
Updated README now that we no longer have "advanced" or "simple" flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To make changes to a `release/x.y` branch, create a `hotfix/*` branch, cherry-pi
 
 Beehive Flow is designed so that every commit can be published. To avoid conflicts with stable releases, the version in
 the `package.json` will almost always be a "release candidate" version like `x.y.z-rc`. A stable release takes place in
-two stages: `beehive-flow release` and `beehive-flow advance-ci`:
+two stages: `beehive-flow release` and `beehive-flow advance-ci`. The two-stage process is shown below:
 
 ```
  main

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ is based on the following questions:
 If the branch `release/a.b` exists, then all releases of the form `a.b.*` should take place from that branch. The
 version set in this branch will already be `a.b.x-rc`, so no manual editing of the version is necessary.
 
-2. Have you upgraded the `main` branch version past `a.b.*`?
+2. Have you upgraded the `main` branch version above `a.b.*`?
 
 If no `release/a.b` branch exists, but the version on main is already greater than `a.b.*`, you will need to create a
 `release/a.b` branch. Run `beehive-flow revive a.b` to create this branch, which will have its version automatically
@@ -229,7 +229,7 @@ This command allows a `release/a.b` branch to be created from previous release t
 
 Version changes:
 
-- `release/a.b`: `a.b.c` -> `a.b.c-rc`
+- `release/a.b`: `a.b.c` -> `a.b.d-rc`
 
 ### prepare
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To make changes to a `release/x.y` branch, create a `hotfix/*` branch, cherry-pi
 
 Beehive Flow is designed so that every commit can be published. To avoid conflicts with stable releases, the version in
 the `package.json` will almost always be a "release candidate" version like `x.y.z-rc`. A stable release takes place in
-two stages: `beehive-flow release` and `behive-flow advance-ci`:
+two stages: `beehive-flow release` and `beehive-flow advance-ci`:
 
 ```
  main


### PR DESCRIPTION
- Rejigged the "overview" now that we've removed the philosophy of "simple" and "advanced" flows
  - Show "revive" before "prepare" as it's more common
  - Indicate that you don't **need** to do either, they just exist for long term support of old releases
- Simplified the explanation of how releases happen (I hope it's simpler, this bit could probably roll back if you prefer it the old way)
- Added a separate section on figuring out which branch to release from, which doubles as a more in-depth explanation of the system we've replaced the "flow"s with
- Promoted "how do I do major (or minor) upgrades" from the FAQ to its own section
- Reorder where the commands are explained
  - Hopefully this new order makes a little more sense wrt. grouping
  - More importantly, `prepare` is no longer the first command that we show people
- Mentioned the updates to the `stamp` command that we did after noticing that issue with commit hashes that started with 0