### PR TITLE
TINY-7701: Changed spike branches to use the alpha version prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- `spike` branches now use `alpha` as the pre-release version prefix #TINY-7701
+
 ## 0.16.0 - 2021-07-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "version": "0.16.1-rc",
+  "version": "0.17.0-rc",
   "name": "@tinymce/beehive-flow"
 }

--- a/src/main/ts/core/PackageJson.ts
+++ b/src/main/ts/core/PackageJson.ts
@@ -87,7 +87,8 @@ const hasPreReleaseDependency = (version: string) =>
   version.includes('-' + PreRelease.releaseCandidate) ||
   version.includes('-' + PreRelease.featureBranch) ||
   version.includes('-' + PreRelease.hotfixBranch) ||
-  version.includes('-' + PreRelease.spikeBranch);
+  version.includes('-' + PreRelease.spikeBranch) ||
+  version.includes('-spike'); // Legacy spike branch prefix
 
 const lookupDeps = (pj: PackageJson, name: 'dependencies' | 'devDependencies', filter: (name: string) => boolean) => pipe(
   O.fromNullable(pj[name]),

--- a/src/main/ts/core/PreRelease.ts
+++ b/src/main/ts/core/PreRelease.ts
@@ -1,4 +1,4 @@
 export const releaseCandidate = 'rc';
 export const featureBranch = 'feature';
 export const hotfixBranch = 'hotfix';
-export const spikeBranch = 'spike';
+export const spikeBranch = 'alpha';

--- a/src/test/ts/commands/ReviveTest.ts
+++ b/src/test/ts/commands/ReviveTest.ts
@@ -24,30 +24,32 @@ describe('Revive', () => {
     return { git, dir };
   };
 
+  const TIMEOUT = 4000;
+
   it('revives version from 1.0.0 tag', async () => {
     const { git, dir } = await runScenario([ '0.1.0', '1.0.0' ], [], '1.0');
     await assert.becomes(Git.currentBranch(git), 'release/1.0');
     await assert.becomes(readPjVersionInDir(dir), '1.0.1-rc');
-  });
+  }).timeout(TIMEOUT);
 
   it('revives version when multiple tags exist', async () => {
     const { git, dir } = await runScenario([ '0.1.0', '1.0.0', '1.1.0', '1.1.1', '1.1.2' ], [ 'release/1.0' ], '1.1');
     await assert.becomes(Git.currentBranch(git), 'release/1.1');
     await assert.becomes(readPjVersionInDir(dir), '1.1.3-rc');
-  });
+  }).timeout(TIMEOUT);
 
   it('fails if a release branch already exists', async () => {
     const result = runScenario([ '1.0.0' ], [ 'release/1.0' ], '1.0');
     await assert.isRejected(result, 'Remote branch already exists: release/1.0');
-  });
+  }).timeout(TIMEOUT);
 
   it('fails if main is at the same major.minor version', async () => {
     const result = runScenario([ '0.0.1' ], [], '0.1');
     await assert.isRejected(result, 'main branch is still at version: 0.1');
-  });
+  }).timeout(TIMEOUT);
 
   it('fails if no tags exist for the specified major.major version', async () => {
     const result = runScenario([ '0.0.1' ], [], '1.0');
     await assert.isRejected(result, 'Failed to find any tags matching version: 1.0');
-  });
+  }).timeout(TIMEOUT);
 });

--- a/src/test/ts/commands/StampTest.ts
+++ b/src/test/ts/commands/StampTest.ts
@@ -43,6 +43,11 @@ describe('Stamp', () => {
       assert.equal(Version.versionToString(actual), `1.2.0-hotfix.${timeFormatted}.shaf0d52ad`);
     });
 
+    it('makes a timestamped version on spike branch', async () => {
+      const actual = Stamp.chooseNewVersion(BranchState.Spike, await Version.parseVersion('1.2.0-rc'), 'f0d52ad', timeMillis);
+      assert.equal(Version.versionToString(actual), `1.2.0-alpha.${timeFormatted}.shaf0d52ad`);
+    });
+
     it('makes a timestamped version in rc state', async () => {
       const actual = Stamp.chooseNewVersion(BranchState.ReleaseCandidate, await Version.parseVersion('1.2.0-rc'), 'f0d52ad', timeMillis);
       assert.equal(Version.versionToString(actual), `1.2.0-rc.${timeFormatted}.shaf0d52ad`);

--- a/src/test/ts/core/PackageJsonTest.ts
+++ b/src/test/ts/core/PackageJsonTest.ts
@@ -116,13 +116,14 @@ describe('PackageJson', () => {
         dependencies: {
           dep1: '^5.0.0-rc',
           dep2: '^5.0.0-feature.20210525.sha123456',
-          dep3: '^5.0.0-spike.20210525.shaabcdef',
-          dep4: '^5.0.0-hotfix.20210525.sha123abc',
+          dep3: '^5.0.0-alpha.20210525.shaabcdef',
+          dep4: '^5.0.0-spike.20210525.sha456def',
+          dep5: '^5.0.0-hotfix.20210525.sha123abc',
           beehive: '^0.16.0'
         }
       };
       const result = PackageJson.shouldNotHavePreReleasePackages(pj);
-      await assert.isRejected(result, 'Pre-release versions were found for: dep1, dep2, dep3, dep4');
+      await assert.isRejected(result, 'Pre-release versions were found for: dep1, dep2, dep3, dep4, dep5');
     });
 
     it('should fail when the beehive dev dependency is a pre-release version', async () => {
@@ -142,7 +143,7 @@ describe('PackageJson', () => {
         devDependencies: {
           dep1: '^5.0.0-rc',
           dep2: '^5.0.0-feature.20210525.sha123456',
-          dep3: '^5.0.0-spike.20210525.shaabcdef',
+          dep3: '^5.0.0-alpha.20210525.shaabcdef',
           dep4: '^5.0.0-hotfix.20210525.sha123abc'
         }
       };


### PR DESCRIPTION
This was an issue realised during the week when upgrading. Since `spike` has a higher precedence than `rc` it means spikes are used instead of the latest release when upgrading. So this swaps to using `alpha` as the pre-release version prefix to ensure it has the lowest precedence (open to other prefixes if someone can think of something else).

Note: This also increases the timeout of the revive command test as it was flaking occasionally.