### PR TITLE
TINY-8756: Updated GitHub CODEOWNERS and PR template files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ashfordneil @JamesToohey @lnewson @metricjs @tiny-james
+* @tinymce/tinymce-reviewers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Related Ticket: 
+
+Description of Changes:
+* Placeholder text
+
+Pre-checks:
+* [ ] Changelog entry added
+* [ ] package.json version bumped (if first change of new major/minor)
+* [ ] Tests have been added (if applicable)
+
+Before merging:
+* [ ] Ensure internal dependencies are on appropriate versions
+  * For stable releases, all dependencies must be stable
+  * For release candidates, all dependencies must be release candidates or stable


### PR DESCRIPTION
Related Ticket: TINY-8756

Description of Changes:
* Update the codeowners to use the new reviewers group
* Added a PR template

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
* [ ] Review comments resolved
