### PR TITLE
TINY-9099: Upgrade to the latest waluigi version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,9 @@ tinyPods.node() {
   }
 
   stage("test") {
+    // Beehive tests require global git username/email setup
+    exec("git config --global user.name \"ephox\"")
+    exec("git config --global user.email \"is-accounts@tiny.cloud\"")
     exec("yarn test")
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,37 +1,35 @@
 #!groovy
-@Library('waluigi@v3.3.0') _
+@Library('waluigi@v6.0.1') _
 
 standardProperties()
 
-node("primary") {
-  stage("checkout") {
-    checkout scm
-  }
-
+tinyPods.node() {
   stage("deps") {
-    sh "yarn install"
+    yarnInstall()
   }
 
   stage("stamp") {
-    sh "yarn beehive-flow stamp"
+    exec("yarn beehive-flow stamp")
   }
 
   stage("build") {
-    sh "yarn build"
+    exec("yarn build")
   }
 
   stage("lint") {
-    sh "yarn lint"
+    exec("yarn lint")
   }
 
   stage("test") {
-    sh "yarn test"
+    exec("yarn test")
   }
 
   stage("publish") {
-    sshagent(credentials: ['jenkins2-github']) {
-      sh "yarn beehive-flow publish"
-      sh "yarn beehive-flow advance-ci"
+    tinyGit.withGitHubSSHCredentials {
+      tinyNpm.withNpmPublishCredentials {
+        sh "yarn beehive-flow publish"
+        sh "yarn beehive-flow advance-ci"
+      }
     }
   }
 }

--- a/src/test/ts/commands/StatusTest.ts
+++ b/src/test/ts/commands/StatusTest.ts
@@ -1,3 +1,4 @@
+import * as cp from 'child_process';
 import { assert } from 'chai';
 import * as O from 'fp-ts/Option';
 import { describe, it } from 'mocha';
@@ -17,9 +18,22 @@ const check = async (dir: string, expected: Object) => {
 };
 
 describe('Status', () => {
+  let verdaccio: cp.ChildProcess;
+  let address: string;
+
+  before(async () => {
+    const v = await TestUtils.startVerdaccio();
+    verdaccio = v.verdaccio;
+    address = v.address;
+  });
+
+  after(() => {
+    verdaccio.kill();
+  });
+
   it('shows status for main branch in preRelease state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.1.0-rc');
+    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.1.0-rc', {}, address);
 
     await check(dir, {
       branchState: 'releaseCandidate',
@@ -38,7 +52,7 @@ describe('Status', () => {
 
   it('shows status for main branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.7.0');
+    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.7.0', {}, address);
 
     await check(dir, {
       branchState: 'releaseReady',
@@ -56,7 +70,7 @@ describe('Status', () => {
 
   it('shows status for release branch in preRelease state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.2-rc');
+    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.2-rc', {}, address);
 
     await check(dir, {
       branchState: 'releaseCandidate',
@@ -75,7 +89,7 @@ describe('Status', () => {
 
   it('shows status for release branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.7');
+    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.7', {}, address);
 
     await check(dir, {
       branchState: 'releaseReady',
@@ -93,7 +107,7 @@ describe('Status', () => {
 
   it('shows status for dependabot branch in feature state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'dependabot/npm_and_yarn/package-1.98.0', dir, 'test-status', '0.1.0-feature.20210525.shaabcdef');
+    await TestUtils.makeBranchWithPj(git, 'dependabot/npm_and_yarn/package-1.98.0', dir, 'test-status', '0.1.0-feature.20210525.shaabcdef', {}, address);
 
     await check(dir, {
       branchState: 'feature',


### PR DESCRIPTION
Related Ticket: TINY-9099

Description of Changes:
* Upgrade to the latest version of waluigi to build using containers
* Fixed the beehive tests not running on Node.js versions > 12.x

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
