### PR TITLE
TINY-9204: Added the ability to update the CHANGELOG.md file on release automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Keep A Changelog files will now get a release header added automatically. This can be prevented with the `--no-release` argument. #TINY-9204
+- Keep A Changelog files will now get a release header added automatically. This can be prevented with the `--no-changelog` argument. #TINY-9204
 
 ## 0.18.0 - 2022-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Keep A Changelog files will now get a release header added automatically. This can be prevented with the `--no-release` argument. #TINY-9204
+
 ## 0.18.0 - 2022-04-21
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cross-spawn-promise": "^0.10.2",
     "fp-ts": "^2.9.5",
     "io-ts": "^2.2.14",
+    "keep-a-changelog": "^2.1.0",
     "luxon": "^1.26.0",
     "properties-reader": "^2.2.0",
     "read-pkg": "^5.2.0",
@@ -90,6 +91,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "version": "0.18.1-rc",
+  "version": "0.19.0-rc",
   "name": "@tinymce/beehive-flow"
 }

--- a/src/main/ts/args/BeehiveArgs.ts
+++ b/src/main/ts/args/BeehiveArgs.ts
@@ -17,6 +17,7 @@ export interface ReleaseArgs extends BaseArgs {
   readonly branchName: string;
   readonly gitUrl: Option<string>;
   readonly allowPreReleaseDeps: boolean;
+  readonly noChangelog: boolean;
 }
 
 export interface AdvanceArgs extends BaseArgs {
@@ -59,7 +60,7 @@ export const prepareArgs = (dryRun: boolean, workingDir: string, temp: Option<st
 });
 
 export const releaseArgs = (
-  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string, allowPreReleaseDeps: boolean
+  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string, allowPreReleaseDeps: boolean, noChangelog: boolean
 ): ReleaseArgs => ({
   kind: 'ReleaseArgs',
   dryRun,
@@ -67,7 +68,8 @@ export const releaseArgs = (
   temp,
   gitUrl,
   branchName,
-  allowPreReleaseDeps
+  allowPreReleaseDeps,
+  noChangelog
 });
 
 export const advanceArgs = (

--- a/src/main/ts/args/Parser.ts
+++ b/src/main/ts/args/Parser.ts
@@ -59,6 +59,12 @@ const allowPreReleaseDepsOptions: yargs.Options = {
   default: false
 };
 
+const noChangelogReleaseOptions: yargs.Options = {
+  description: 'Prevent the changelog from being updated.',
+  type: 'boolean',
+  default: false
+};
+
 const getColumns = (): number =>
   Math.min(120, yargs.terminalWidth());
 
@@ -90,6 +96,7 @@ const argParser =
         .option('git-url', gitUrlOptions)
         .option('temp', tempOptions)
         .option('allow-pre-releases', allowPreReleaseDepsOptions)
+        .option('no-changelog', noChangelogReleaseOptions),
     )
     .command(
       'advance <majorMinorOrMain>',
@@ -179,7 +186,15 @@ export const parseArgs = async (args: string[]): Promise<Option<BeehiveArgs>> =>
     return O.some(BeehiveArgs.prepareArgs(dryRun, workingDir, temp(), gitUrl()));
 
   } else if (cmd === 'release') {
-    return O.some(BeehiveArgs.releaseArgs(dryRun, workingDir, temp(), gitUrl(), await majorMinorOrMain(), a['allow-pre-releases'] as boolean));
+    return O.some(BeehiveArgs.releaseArgs(
+      dryRun,
+      workingDir,
+      temp(),
+      gitUrl(),
+      await majorMinorOrMain(),
+      a['allow-pre-releases'] as boolean,
+      a['no-changelog'] as boolean
+    ));
 
   } else if (cmd === 'advance') {
     return O.some(BeehiveArgs.advanceArgs(dryRun, workingDir, temp(), gitUrl(), await majorMinorOrMain()));

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -10,12 +10,10 @@ import { BranchState, getBranchDetails, Module } from '../core/BranchLogic';
 import * as Changelog from '../keepachangelog/Changelog';
 import { printHeaderMessage } from '../core/Messages';
 
-const updateChangelog = async (git: SimpleGit, dryRun: boolean, version: Version.Version, module: Module) => {
+const updateChangelog = async (git: SimpleGit, version: Version.Version, module: Module) => {
   const changelogFile = module.changelogFile;
   if (module.changelogFormat === 'none') {
     console.log('No changelog file found');
-  } else if (dryRun) {
-    console.log('dry-run - not updating the changelog');
   } else {
     // NOTE: Add other changelog formats updates here if we support more
     await Changelog.updateFromFile(changelogFile, version);
@@ -55,7 +53,7 @@ export const release = async (args: ReleaseArgs): Promise<void> => {
   await PackageJson.writePackageJsonFileWithNewVersion(rootModule.packageJson, newVersion, rootModule.packageJsonFile);
 
   if (!args.noChangelog) {
-    await updateChangelog(git, args.dryRun, newVersion, rootModule);
+    await updateChangelog(git, newVersion, rootModule);
   }
 
   await git.add(rootModule.packageJsonFile);

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -12,12 +12,11 @@ import { printHeaderMessage } from '../core/Messages';
 
 const updateChangelog = async (git: SimpleGit, version: Version.Version, module: Module) => {
   const changelogFile = module.changelogFile;
-  if (module.changelogFormat === 'none') {
-    console.log('No changelog file found');
-  } else {
-    // NOTE: Add other changelog formats updates here if we support more
+  if (module.changelogFormat === 'keepachangelog') {
     await Changelog.updateFromFile(changelogFile, version);
     await git.add(changelogFile);
+  } else {
+    console.log('No changelog file found');
   }
 };
 

--- a/src/main/ts/core/BranchLogic.ts
+++ b/src/main/ts/core/BranchLogic.ts
@@ -40,7 +40,7 @@ export const enum BranchState {
 
 interface ModuleChangelog {
   readonly changelogFile: string;
-  readonly changelogFormat: string;
+  readonly changelogFormat: 'keepachangelog' | 'none';
 }
 
 export interface Module extends ModuleChangelog {

--- a/src/main/ts/core/BranchLogic.ts
+++ b/src/main/ts/core/BranchLogic.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as O from 'fp-ts/Option';
 import { gitP, CheckRepoActions, SimpleGit } from 'simple-git';
@@ -37,7 +38,12 @@ export const enum BranchState {
   ReleaseCandidate = 'releaseCandidate'
 }
 
-export interface Module {
+interface ModuleChangelog {
+  readonly changelogFile: string;
+  readonly changelogFormat: string;
+}
+
+export interface Module extends ModuleChangelog {
   readonly packageJson: PackageJson;
   readonly packageJsonFile: string;
 }
@@ -92,12 +98,29 @@ export const getBranchType = (branchName: string): Option<BranchType> => {
 export const isValidPrerelease = (actual: string | undefined, expected: string): boolean =>
   actual !== undefined && (actual === expected || actual.startsWith(`${expected}.`));
 
+const findChangelog = (dir: string): ModuleChangelog => {
+  const changelogFile = path.join(dir, 'CHANGELOG.md');
+  if (fs.existsSync(changelogFile)) {
+    return {
+      changelogFile,
+      changelogFormat: 'keepachangelog'
+    };
+  } else {
+    return {
+      changelogFile: '',
+      changelogFormat: 'none'
+    };
+  }
+};
+
 const readModule = async (dir: string): Promise<Module> => {
   const packageJsonFile = path.join(dir, 'package.json');
   const packageJson = await PackageJson.parsePackageJsonFile(packageJsonFile);
+  const changelog = findChangelog(dir);
   return {
     packageJson,
-    packageJsonFile
+    packageJsonFile,
+    ...changelog
   };
 };
 

--- a/src/main/ts/keepachangelog/Changelog.ts
+++ b/src/main/ts/keepachangelog/Changelog.ts
@@ -17,7 +17,7 @@ export type Release = KeepAChangelog.Release;
 export type Change = KeepAChangelog.Change;
 
 class CustomRelease extends KeepAChangelog.Release {
-  public constructor(version?: string, date?: Date | string, description?: string) {
+  public constructor(version?: Semver | string, date?: Date | string, description?: string) {
     super(version, date, description);
     // Add in "improved" and ensure the ordering
     const changeTypes: Array<[ string, Change[] ]> = [
@@ -44,7 +44,7 @@ class CustomRelease extends KeepAChangelog.Release {
 }
 
 // Attempt to find the specific release if not fallback to finding the unreleased section
-export const findRelease = (changelog: Changelog, version: string): O.Option<CustomRelease> =>
+const findRelease = (changelog: Changelog, version: string): O.Option<CustomRelease> =>
   O.fromNullable(changelog.findRelease(version) ?? changelog.findRelease());
 
 export const parse = (content: string): Changelog =>

--- a/src/main/ts/keepachangelog/Changelog.ts
+++ b/src/main/ts/keepachangelog/Changelog.ts
@@ -1,0 +1,87 @@
+import { pipe } from 'fp-ts/function';
+import * as O from 'fp-ts/Option';
+import * as KeepAChangelog from 'keep-a-changelog';
+import { Semver } from 'keep-a-changelog/types/src/deps';
+import { DateTime } from 'luxon';
+import * as Version from '../core/Version';
+import * as Files from '../utils/Files';
+
+export interface Changelog extends KeepAChangelog.Changelog {
+  releases: CustomRelease[];
+  addRelease(release: CustomRelease): this;
+  findRelease(version?: Semver | string): CustomRelease | undefined;
+  tagName(release: CustomRelease): string;
+}
+
+export type Release = KeepAChangelog.Release;
+export type Change = KeepAChangelog.Change;
+
+class CustomRelease extends KeepAChangelog.Release {
+  public constructor(version?: string, date?: Date | string, description?: string) {
+    super(version, date, description);
+    // Add in "improved" and ensure the ordering
+    const changeTypes: Array<[ string, Change[] ]> = [
+      [ 'added', []],
+      [ 'improved', []],
+      [ 'changed', []],
+      [ 'fixed', []],
+      [ 'security', []],
+      [ 'deprecated', []],
+      [ 'removed', []]
+    ];
+
+    this.changes = new Map(changeTypes);
+  }
+
+  public improved(change: Change) {
+    return this.addChange('improved', change);
+  }
+
+  public toString(changelog?: Changelog): string {
+    // Ensure new lines between the version header and section header
+    return super.toString(changelog).replace(/## (.+)\n###/g, '## $1\n\n###');
+  }
+}
+
+const findRelease = (changelog: Changelog, version?: string): O.Option<CustomRelease> =>
+  O.fromNullable(changelog.findRelease(version));
+
+export const parse = (content: string): Changelog =>
+  KeepAChangelog.parser(content, {
+    releaseCreator: (version?: string, date?: string, description?: string) => new CustomRelease(version, date, description)
+  }) as Changelog;
+
+export const update = (content: string, version: Version.Version) => {
+  const versionString = Version.versionToString(version);
+  const date = DateTime.now();
+  const dateString = date.toFormat('yyyy-MM-dd');
+  const changelog = parse(content);
+
+  // Find the current version, if not find unreleased and update the version
+  const release = pipe(
+    findRelease(changelog, versionString),
+    O.alt(() => findRelease(changelog)),
+    O.filter((current) => !current.isEmpty()),
+    O.map((current) => {
+      const isUnreleased = current.version === undefined;
+      if (isUnreleased) {
+        console.log(`Changing unreleased changelog header to ${versionString} - ${dateString}`);
+        current.setVersion(versionString);
+        changelog.addRelease(new CustomRelease());
+      } else {
+        console.log(`Updating existing changelog header to ${versionString} - ${dateString}`);
+      }
+      current.setDate(date.toJSDate());
+      return current;
+    })
+  );
+
+  return O.isSome(release) ? changelog.toString() : content;
+};
+
+export const updateFromFile = async (changelogFile: string, version: Version.Version) => {
+  const content = await Files.readFileAsString(changelogFile);
+  const newContent = update(content, version);
+  console.log(`Saving changes to ${changelogFile}`);
+  await Files.writeFile(changelogFile, newContent);
+};

--- a/src/main/ts/keepachangelog/Changelog.ts
+++ b/src/main/ts/keepachangelog/Changelog.ts
@@ -43,8 +43,9 @@ class CustomRelease extends KeepAChangelog.Release {
   }
 }
 
-const findRelease = (changelog: Changelog, version?: string): O.Option<CustomRelease> =>
-  O.fromNullable(changelog.findRelease(version));
+// Attempt to find the specific release if not fallback to finding the unreleased section
+export const findRelease = (changelog: Changelog, version: string): O.Option<CustomRelease> =>
+  O.fromNullable(changelog.findRelease(version) ?? changelog.findRelease());
 
 export const parse = (content: string): Changelog =>
   KeepAChangelog.parser(content, {
@@ -60,7 +61,6 @@ export const update = (content: string, version: Version.Version) => {
   // Find the current version, if not find unreleased and update the version
   const release = pipe(
     findRelease(changelog, versionString),
-    O.alt(() => findRelease(changelog)),
     O.filter((current) => !current.isEmpty()),
     O.map((current) => {
       const isUnreleased = current.version === undefined;

--- a/src/test/data/keepachangelog/test_ok_standard.md
+++ b/src/test/data/keepachangelog/test_ok_standard.md
@@ -1,0 +1,76 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+- Fixed an issue where the image dialog tried to calculate image dimensions for an empty image URL. #TINY-6611
+
+## 5.6.2 - 2020-12-08
+
+### Fixed
+- Fixed a UI rendering regression observed when the document body is using `display: flex`. #TINY-6783
+
+## 5.6.1 - 2020-11-25
+
+### Fixed
+- Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event. #TINY-6692
+- Fixed the HTML5 `s` element was not recognized when editing or clearing text formatting. #TINY-6681
+- Fixed an issue where copying and pasting table columns resulted in invalid HTML when using colgroups. #TINY-6684
+- Fixed an issue where the toolbar would render with the wrong width for inline editors in some situations. #TINY-6683
+
+## 5.6.0 - 2020-11-18
+
+### Added
+- Added new `BeforeOpenNotification` and `OpenNotification` events which allow internal notifications to be captured and modified before display. #TINY-6528
+- Added support for the `block` and `unblock` methods on inline dialogs. #TINY-6487
+- Added a new `TableModified` event which is fired whenever changes are made to a table. #TINY-6629
+- Added a new `images_file_types` setting to determine which image file formats will be automatically processed into `img` tags on paste when using the `paste` plugin. #TINY-6306
+- Introduced support for `images_file_types` setting in the image file uploader to determine which image file extensions are valid for upload. #TINY-6224
+- Added new a `format_empty_lines` setting to control if empty lines are formatted in a ranged selection. #TINY-6483
+- Added template support to the `autocompleter` for customizing the autocompleter items. #TINY-6505
+- Introduced new user interface `enable`, `disable`, and `isDisabled` methods. #TINY-6397
+- Added a new `closest` formatter API to get the closest matching selection format from a set of formats. #TINY-6479
+- Added a new `emojiimages` emoticons database that uses the twemoji CDN by default. #TINY-6021
+- Added a new `emoticons_database` setting to configure which emoji database to use. #TINY-6021
+
+### Improved
+- Added a new `name` field to the `style_formats` setting object to enable specifying a name for the format. #TINY-4239
+
+### Changed
+- Changed `readonly` mode to allow hyperlinks to be clickable. #TINY-6248
+
+### Fixed
+- Fixed the `change` event not firing after a successful image upload. #TINY-6586
+- Fixed the type signature for the `entity_encoding` setting not accepting delimited lists. #TINY-6648
+- Fixed layout issues when empty `tr` elements were incorrectly removed from tables. #TINY-4679
+- Fixed image file extensions lost when uploading an image with an alternative extension, such as `.jfif`. #TINY-6622
+- Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned. #TINY-6540
+- Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root. #TINY-6363
+- Fixed `getContent` with text format returning a new line when the editor is empty. #TINY-6281
+- Fixed table column and row resizers not respecting the `data-mce-resize` attribute. #TINY-6600
+- Fixed inserting a table via the `mceInsertTable` command incorrectly creating 2 undo levels. #TINY-6656
+- Fixed nested tables with `colgroup` elements incorrectly always resizing the inner table. #TINY-6623
+- Fixed the `visualchars` plugin causing the editor to steal focus when initialized. #TINY-6282
+- Fixed `fullpage` plugin altering text content in `editor.getContent()`. #TINY-6541
+- Fixed `fullscreen` plugin not working correctly with multiple editors and shadow DOM. #TINY-6280
+- Fixed font size keywords such as `medium` not displaying correctly in font size menus. #TINY-6291
+- Fixed an issue where some attributes in table cells were not copied over to new rows or columns. #TINY-6485
+- Fixed incorrectly removing formatting on adjacent spaces when removing formatting on a ranged selection. #TINY-6268
+- Fixed the `Cut` menu item not working in the latest version of Mozilla Firefox. #TINY-6615
+- Fixed some incorrect types in the new TypeScript declaration file. #TINY-6413
+- Fixed a regression where a fake offscreen selection element was incorrectly created for the editor root node. #TINY-6555
+- Fixed an issue where menus would incorrectly collapse in small containers. #TINY-3321
+- Fixed an issue where only one table column at a time could be converted to a header. #TINY-6326
+- Fixed some minor memory leaks that prevented garbage collection for editor instances. #TINY-6570
+- Fixed resizing a `responsive` table not working when using the column resize handles. #TINY-6601
+- Fixed incorrectly calculating table `col` widths when resizing responsive tables. #TINY-6646
+- Fixed an issue where spaces were not preserved in pre-blocks when getting text content. #TINY-6448
+- Fixed a regression that caused the selection to be difficult to see in tables with backgrounds. #TINY-6495
+- Fixed content pasted multiple times in the editor when using Microsoft Internet Explorer 11. Patch contributed by mattford. #GH-4905
+
+### Security
+- Fixed a moderate severity security issue where URLs in attributes weren't correctly sanitized. #TINY-6518

--- a/src/test/ts/args/ParserTest.ts
+++ b/src/test/ts/args/ParserTest.ts
@@ -30,11 +30,11 @@ describe('Parser', () => {
       await fc.assert(fc.asyncProperty(fc.nat(100), fc.nat(100), async (major, minor) => {
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}` ]),
-          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false))
+          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false))
         );
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}`, '--dry-run' ]),
-          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false))
+          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false))
         );
       }));
     });
@@ -42,7 +42,7 @@ describe('Parser', () => {
     it('succeeds for release command with main arg', async () => {
       await assert.becomes(
         parseArgs([ 'release', 'main' ]),
-        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main', false))
+        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main', false, false))
       );
     });
 

--- a/src/test/ts/commands/PublishTest.ts
+++ b/src/test/ts/commands/PublishTest.ts
@@ -41,11 +41,11 @@ describe('Publish', () => {
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
 
     // publish a dummy version, so we have something as "latest"
-    await TestUtils.makeBranchWithPj(git, 'feature/dummy', dir, packageName, '0.0.1-rc', {}, address);
+    await TestUtils.makeBranchWithPj(git, 'feature/dummy', dir, packageName, '0.0.1-rc', undefined, {}, address);
     await publish(dryRun, dir);
 
     // publish the version we care about
-    const pjFile = await TestUtils.makeBranchWithPj(git, branchName, dir, packageName, version, {}, address);
+    const pjFile = await TestUtils.makeBranchWithPj(git, branchName, dir, packageName, version, undefined, {}, address);
     await stamp(dir);
     const stampedVersion = await TestUtils.readPjVersion(pjFile);
     await publish(dryRun, dir);

--- a/src/test/ts/commands/ReleaseTest.ts
+++ b/src/test/ts/commands/ReleaseTest.ts
@@ -1,13 +1,20 @@
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as Git from '../../../main/ts/utils/Git';
-import { beehiveFlow, makeBranchWithPj, readPjVersionInDir, writeAndAddLocalFile } from './TestUtils';
+import { beehiveFlow, makeBranchWithPj, readKeepAChangelogInDir, readPjVersionInDir, writeAndAddLocalFile } from './TestUtils';
 
 describe('Release', () => {
-  const runScenario = async (branchName: string, version: string, arg: string, dependencies: Record<string, string> = {}, additionalArgs: string[] = []) => {
+  const runScenario = async (
+    branchName: string,
+    version: string,
+    arg: string,
+    newVersion?: string,
+    dependencies: Record<string, string> = {},
+    additionalArgs: string[] = []
+  ) => {
     const hub = await Git.initInTempFolder(true);
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
-    await makeBranchWithPj(git, branchName, dir, 'test-release', version, dependencies);
+    await makeBranchWithPj(git, branchName, dir, 'test-release', version, newVersion, dependencies);
     await beehiveFlow([ 'release', arg, '--working-dir', dir, ...additionalArgs ]);
     await git.pull();
     return dir;
@@ -24,12 +31,12 @@ describe('Release', () => {
   });
 
   it('fails to release when a dependency still uses a pre-release version', async () => {
-    const result = runScenario('main', '0.1.0-rc', 'main', { dep1: '~3.2.0-rc' });
+    const result = runScenario('main', '0.1.0-rc', 'main', undefined, { dep1: '~3.2.0-rc' });
     await assert.isRejected(result, 'Pre-release versions were found for: dep1');
   });
 
   it('releases if --allow-pre-releases is enabled when a pre-release dependency exists', async () => {
-    const dir = await runScenario('main', '0.1.0-rc', 'main', { dep1: '~3.2.0-rc' }, [ '--allow-pre-releases' ]);
+    const dir = await runScenario('main', '0.1.0-rc', 'main', undefined, { dep1: '~3.2.0-rc' }, [ '--allow-pre-releases' ]);
     await assert.becomes(readPjVersionInDir(dir), '0.1.0');
   });
 
@@ -52,5 +59,31 @@ describe('Release', () => {
     await writeAndAddLocalFile(git, dir, 'file.text');
     await git.commit('commit msg');
     await assert.isRejected(beehiveFlow([ 'release', 'main', '--working-dir', dir ]));
+  });
+
+  it('Adds the changelog version and date', async () => {
+    const dir = await runScenario('main', '0.1.0-rc', 'main');
+    await assert.becomes(readPjVersionInDir(dir), '0.1.0');
+    const changelog = await readKeepAChangelogInDir(dir);
+    const unreleased = changelog.releases[0];
+    const releaseSection = changelog.releases[1];
+    assert.isTrue(unreleased.isEmpty(), 'Unreleased section exists and is empty');
+    assert.isFalse(releaseSection.isEmpty(), 'Release section should not be empty');
+    assert.equal(releaseSection.version?.compare('0.1.0'), 0);
+    assert.equal(releaseSection.date?.getFullYear(), new Date().getFullYear());
+    assert.equal(releaseSection.date?.getMonth(), new Date().getMonth());
+    assert.equal(releaseSection.date?.getDate(), new Date().getDate());
+  });
+
+  it('Updates the changelog date if it already exists', async () => {
+    const dir = await runScenario('main', '1.0.0-rc', 'main', '1.0.0');
+    await assert.becomes(readPjVersionInDir(dir), '1.0.0');
+    const changelog = await readKeepAChangelogInDir(dir);
+    const releaseSection = changelog.releases[0];
+    assert.isFalse(releaseSection.isEmpty(), 'Release section should not be empty');
+    assert.equal(releaseSection.version?.compare('1.0.0'), 0);
+    assert.equal(releaseSection.date?.getFullYear(), new Date().getFullYear());
+    assert.equal(releaseSection.date?.getMonth(), new Date().getMonth());
+    assert.equal(releaseSection.date?.getDate(), new Date().getDate());
   });
 });

--- a/src/test/ts/commands/StatusTest.ts
+++ b/src/test/ts/commands/StatusTest.ts
@@ -33,7 +33,7 @@ describe('Status', () => {
 
   it('shows status for main branch in preRelease state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.1.0-rc', {}, address);
+    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.1.0-rc', undefined, {}, address);
 
     await check(dir, {
       branchState: 'releaseCandidate',
@@ -52,7 +52,7 @@ describe('Status', () => {
 
   it('shows status for main branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.7.0', {}, address);
+    await TestUtils.makeBranchWithPj(git, 'main', dir, 'test-status', '0.7.0', undefined, {}, address);
 
     await check(dir, {
       branchState: 'releaseReady',
@@ -70,7 +70,7 @@ describe('Status', () => {
 
   it('shows status for release branch in preRelease state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.2-rc', {}, address);
+    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.2-rc', undefined, {}, address);
 
     await check(dir, {
       branchState: 'releaseCandidate',
@@ -89,7 +89,7 @@ describe('Status', () => {
 
   it('shows status for release branch in releaseReady state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.7', {}, address);
+    await TestUtils.makeBranchWithPj(git, 'release/1.98', dir, 'test-status', '1.98.7', undefined, {}, address);
 
     await check(dir, {
       branchState: 'releaseReady',
@@ -107,7 +107,15 @@ describe('Status', () => {
 
   it('shows status for dependabot branch in feature state', async () => {
     const { dir, git } = await newGit();
-    await TestUtils.makeBranchWithPj(git, 'dependabot/npm_and_yarn/package-1.98.0', dir, 'test-status', '0.1.0-feature.20210525.shaabcdef', {}, address);
+    await TestUtils.makeBranchWithPj(
+      git,
+      'dependabot/npm_and_yarn/package-1.98.0',
+      dir, 'test-status',
+      '0.1.0-feature.20210525.shaabcdef',
+      undefined,
+      {},
+      address
+    );
 
     await check(dir, {
       branchState: 'feature',

--- a/src/test/ts/core/BranchLogicTest.ts
+++ b/src/test/ts/core/BranchLogicTest.ts
@@ -70,7 +70,7 @@ describe('BranchLogic', () => {
       await PackageJson.writePackageJsonFile(packageJsonFile, packageJson);
       await git.add(packageJsonFile);
       await git.commit('commit');
-      return { gitUrl, dir, packageJsonFile, version, packageJson, changelogFile: '', changelogFormat: 'none' };
+      return { gitUrl, dir, packageJsonFile, version, packageJson, changelogFile: '', changelogFormat: 'none' as const };
     };
 
     it('fails if dir is not a git repo', async () => {
@@ -185,7 +185,7 @@ describe('BranchLogic', () => {
           const changelogFile = path.join(module1Dir, 'CHANGELOG.md');
           await PackageJson.writePackageJsonFile(pjFile, pj);
           await TestUtils.writeChangelog(module1Dir);
-          return { pj, pjFile, changelogFile, changelogFormat: 'keepachangelog' };
+          return { pj, pjFile, changelogFile, changelogFormat: 'keepachangelog' as const };
         };
 
         const m1 = await makeModule('module1');

--- a/src/test/ts/keepachangelog/ChangelogTest.ts
+++ b/src/test/ts/keepachangelog/ChangelogTest.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import { DateTime } from 'luxon';
+import * as Files from '../../../main/ts/utils/Files';
+import { Version } from '../../../main/ts/core/Version';
+import * as Changelog from '../../../main/ts/keepachangelog/Changelog';
+
+const preamble = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+`;
+
+describe('Changelog', () => {
+  context('update', () => {
+    const today = DateTime.now().toFormat('yyyy-MM-dd');
+
+    const go = (input: string, newVersion?: Version): string =>
+      Changelog.update(input, newVersion ?? { major: 1, minor: 0, patch: 0 });
+
+    it('does nothing with only changelog header with no releases', () => {
+      assert.deepEqual(go(preamble), preamble);
+    });
+
+    it('does nothing with only changelog header text and Unreleased header (minimum complete example)', () => {
+      const content = `${preamble}
+## Unreleased
+`;
+      assert.deepEqual(go(content), content);
+    });
+
+    it('updates with only a Unreleased header and content', () => {
+      const content = `${preamble}
+## Unreleased
+
+### Added
+- Content
+`;
+
+      const expected = `${preamble}
+## Unreleased
+
+## 1.0.0 - ${today}
+
+### Added
+- Content
+`;
+      assert.deepEqual(go(content), expected);
+    });
+
+    it('updates an existing header with the right date', () => {
+      const content = `${preamble}
+## 1.0.0 - 2001-01-01
+
+### Added
+- Content
+
+### Improved
+- Content
+`;
+
+      const expected = `${preamble}
+## 1.0.0 - ${today}
+
+### Added
+- Content
+
+### Improved
+- Content
+`;
+      assert.deepEqual(go(content), expected);
+    });
+
+    it('fails with a release header without a date', () => {
+      assert.throws(() => {
+        go(`${preamble}
+## 1.0.0
+
+### Removed
+- Content
+`);
+      });
+    });
+  });
+
+  context('parse', () => {
+    it('can parse a valid changelog entry', async () => {
+      const content = await Files.readFileAsString('src/test/data/keepachangelog/test_ok_standard.md');
+      const changelog = Changelog.parse(content);
+      assert.lengthOf(changelog.releases, 4, 'Number of releases');
+      assert.isUndefined(changelog.releases[0].version, 'An unreleased section exists');
+      assert.equal(changelog.releases[1].version?.compare('5.6.2'), 0);
+      assert.equal(changelog.releases[3].version?.compare('5.6.0'), 0);
+      assert.lengthOf(changelog.releases[3].changes.get('added')!, 11, 'Added entries');
+      assert.lengthOf(changelog.releases[3].changes.get('improved')!, 1, 'Improved entries');
+      assert.lengthOf(changelog.releases[3].changes.get('changed')!, 1, 'Changed entries');
+      assert.lengthOf(changelog.releases[3].changes.get('fixed')!, 27, 'Fixed entries');
+      assert.lengthOf(changelog.releases[3].changes.get('security')!, 1, 'Security entries');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,6 +178,19 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@deno/shim-deno-test@^0.3.2":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@deno/shim-deno-test/-/shim-deno-test-0.3.3.tgz#2dd014a2649507477f904d0172dd88341354086d"
+  integrity sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg==
+
+"@deno/shim-deno@~0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@deno/shim-deno/-/shim-deno-0.4.3.tgz#3bb6a4e3749133f98e8373ea2e79efaa43fb182a"
+  integrity sha512-m5iXsq3Nvv1aJ1xwUQGnXXOztZ5UUF9dZje3l6EbX41zE5+MioK1NN+2+C3nlWWs9PvSFam4EbZVG3JUbLCeDg==
+  dependencies:
+    "@deno/shim-deno-test" "^0.3.2"
+    which "^2.0.2"
+
 "@eslint/eslintrc@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.1.tgz#8b5e1c49f4077235516bc9ec7d41378c0f69b8c6"
@@ -2568,6 +2581,13 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
+keep-a-changelog@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/keep-a-changelog/-/keep-a-changelog-2.1.0.tgz#abedb23407eb6cee3f586e705de457a2b73f3b46"
+  integrity sha512-Svnmt3UTW0U8RdAi24jy2OuU03wEYZkD7vrJuK9u5gIYk6as/BvbSDK0oFtnZLC8xDludDYDsomq7tetEUR0Ow==
+  dependencies:
+    "@deno/shim-deno" "~0.4.3"
+
 keygrip@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
@@ -4353,7 +4373,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@2.0.2, which@^2.0.1:
+which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
Related Ticket: TINY-9024

Description of Changes:

Adds the ability for the `release` command to update the keepachangelog entry automatically. It will either move the `Unreleased` section or update any existing section that matches the new version. I've also added a `--no-changelog` argument to prevent this happening should we want to. Note that this also reorders the changelog sections into the correct order if they were incorrect (Added -> Improved -> etc...) due to how the `keep-a-changelog` library works.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
