### PR TITLE
TINY-9211: Updated the publish command to check the changelog section matches the release type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Keep A Changelog files will now get a release header added automatically. This can be prevented with the `--no-changelog` argument. #TINY-9204
 
+### Improved
+- The `publish` command will check the changelog to ensure the sections in the release match the type of release. #TINY-9211
+
 ### Changed
 - Upgraded dependencies and removed `read-pkg` as it wasn't being used. #TINY-9229
 

--- a/src/main/ts/keepachangelog/Changelog.ts
+++ b/src/main/ts/keepachangelog/Changelog.ts
@@ -1,4 +1,3 @@
-import { Either } from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import * as Arr from 'fp-ts/Array';
 import * as E from 'fp-ts/Either';
@@ -118,7 +117,7 @@ export const checkVersion = (content: string, version: Version.Version): E.Eithe
         return E.right(true);
       }
     }),
-    O.getOrElse((): Either<string, boolean> => E.right(false))
+    O.getOrElse((): E.Either<string, boolean> => E.right(false))
   );
 };
 

--- a/src/main/ts/keepachangelog/Changelog.ts
+++ b/src/main/ts/keepachangelog/Changelog.ts
@@ -1,10 +1,14 @@
+import { Either } from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
+import * as Arr from 'fp-ts/Array';
+import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import * as KeepAChangelog from 'keep-a-changelog';
 import { Semver } from 'keep-a-changelog/types/src/deps';
 import { DateTime } from 'luxon';
 import * as Version from '../core/Version';
 import * as Files from '../utils/Files';
+import * as PromiseUtils from '../utils/PromiseUtils';
 
 export interface Changelog extends KeepAChangelog.Changelog {
   releases: CustomRelease[];
@@ -43,6 +47,12 @@ class CustomRelease extends KeepAChangelog.Release {
   }
 }
 
+const hasAnySectionType = (release: CustomRelease, types: string[]): boolean =>
+  pipe(
+    types,
+    Arr.some((type) => release.changes.has(type) && (release.changes.get(type) as Change[]).length > 0)
+  );
+
 // Attempt to find the specific release if not fallback to finding the unreleased section
 const findRelease = (changelog: Changelog, version: string): O.Option<CustomRelease> =>
   O.fromNullable(changelog.findRelease(version) ?? changelog.findRelease());
@@ -52,7 +62,12 @@ export const parse = (content: string): Changelog =>
     releaseCreator: (version?: string, date?: string, description?: string) => new CustomRelease(version, date, description)
   }) as Changelog;
 
-export const update = (content: string, version: Version.Version) => {
+export const parseFromFile = async (changelogFile: string): Promise<Changelog> => {
+  const content = await Files.readFileAsString(changelogFile);
+  return parse(content);
+};
+
+export const update = (content: string, version: Version.Version): string => {
   const versionString = Version.versionToString(version);
   const date = DateTime.now();
   const dateString = date.toFormat('yyyy-MM-dd');
@@ -79,9 +94,35 @@ export const update = (content: string, version: Version.Version) => {
   return O.isSome(release) ? changelog.toString() : content;
 };
 
-export const updateFromFile = async (changelogFile: string, version: Version.Version) => {
+export const updateFromFile = async (changelogFile: string, version: Version.Version): Promise<void> => {
   const content = await Files.readFileAsString(changelogFile);
   const newContent = update(content, version);
   console.log(`Saving changes to ${changelogFile}`);
   await Files.writeFile(changelogFile, newContent);
+};
+
+export const checkVersion = (content: string, version: Version.Version): E.Either<string, boolean> => {
+  const isPatch = version.patch !== 0;
+  const isMinor = version.minor !== 0;
+  const changelog = parse(content);
+  return pipe(
+    findRelease(changelog, Version.versionToString(version)),
+    O.map((release) => {
+      if (isPatch && hasAnySectionType(release, [ 'added', 'improved' ])) {
+        return E.left('Changelog contains an Added or Improved section for a patch release. This should be at least a minor.');
+      } else if (isPatch && hasAnySectionType(release, [ 'removed' ])) {
+        return E.left('Changelog contains a Removed section for a patch release. This should be at least a major.');
+      } else if (isMinor && hasAnySectionType(release, [ 'removed' ])) {
+        return E.left('Changelog contains a Removed section for a minor release. This should be at least a major.');
+      } else {
+        return E.right(true);
+      }
+    }),
+    O.getOrElse((): Either<string, boolean> => E.right(false))
+  );
+};
+
+export const checkVersionFromFile = async (changelogFile: string, version: Version.Version): Promise<boolean> => {
+  const content = await Files.readFileAsString(changelogFile);
+  return PromiseUtils.eitherToPromise(checkVersion(content, version));
 };

--- a/src/test/ts/commands/ReleaseTest.ts
+++ b/src/test/ts/commands/ReleaseTest.ts
@@ -62,14 +62,14 @@ describe('Release', () => {
   });
 
   it('Adds the changelog version and date', async () => {
-    const dir = await runScenario('main', '0.1.0-rc', 'main');
-    await assert.becomes(readPjVersionInDir(dir), '0.1.0');
+    const dir = await runScenario('main', '0.2.0-rc', 'main');
+    await assert.becomes(readPjVersionInDir(dir), '0.2.0');
     const changelog = await readKeepAChangelogInDir(dir);
     const unreleased = changelog.releases[0];
     const releaseSection = changelog.releases[1];
     assert.isTrue(unreleased.isEmpty(), 'Unreleased section exists and is empty');
     assert.isFalse(releaseSection.isEmpty(), 'Release section should not be empty');
-    assert.equal(releaseSection.version?.compare('0.1.0'), 0);
+    assert.equal(releaseSection.version?.compare('0.2.0'), 0);
     assert.equal(releaseSection.date?.getFullYear(), new Date().getFullYear());
     assert.equal(releaseSection.date?.getMonth(), new Date().getMonth());
     assert.equal(releaseSection.date?.getDate(), new Date().getDate());

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ${heading}
 
+### Fixed
+- Fixed some bug. #GH-1234
+
+## 0.1.0 - 2000-02-02
+
 ### Added
 - Example added entry.
 
@@ -48,8 +53,8 @@ ${heading}
 - Some improved example.
   - Nested entry test.
 
-### Fixed
-- Fixed some bug. #GH-1234
+### Security
+- Fixed vulnerability.
 
 ## 0.0.1 - 2000-01-01
 

--- a/src/test/ts/keepachangelog/ChangelogTest.ts
+++ b/src/test/ts/keepachangelog/ChangelogTest.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import * as E from 'fp-ts/Either';
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import { DateTime } from 'luxon';
@@ -15,11 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `;
 
 describe('Changelog', () => {
+  const createVersion = (major: number, minor: number, patch: number) =>
+    ({ major, minor, patch });
+
   context('update', () => {
     const today = DateTime.now().toFormat('yyyy-MM-dd');
 
     const go = (input: string, newVersion?: Version): string =>
-      Changelog.update(input, newVersion ?? { major: 1, minor: 0, patch: 0 });
+      Changelog.update(input, newVersion ?? createVersion(1, 0, 0));
 
     it('does nothing with only changelog header with no releases', () => {
       assert.deepEqual(go(preamble), preamble);
@@ -99,6 +103,99 @@ describe('Changelog', () => {
       assert.lengthOf(changelog.releases[3].changes.get('changed')!, 1, 'Changed entries');
       assert.lengthOf(changelog.releases[3].changes.get('fixed')!, 27, 'Fixed entries');
       assert.lengthOf(changelog.releases[3].changes.get('security')!, 1, 'Security entries');
+    });
+  });
+
+  context('checkVersion', () => {
+    it('should pass for a patch release with "Fixed" or "Security"', () => {
+      assert.deepEqual(Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Fixed
+- Fixed some bug
+
+### Security
+- Some security issue
+`, createVersion(1, 0, 1)), E.right(true));
+    });
+
+    it('should pass for a minor release with "Changed", "Fixed", "Added" or "Improved"', () => {
+      assert.deepEqual(Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Added
+- Some new feature
+
+### Improved
+- Some enhancement
+
+### Changed
+- Some change
+
+### Fixed
+- Some bug
+`, createVersion(1, 1, 0)), E.right(true));
+    });
+
+    it('should pass for a major release with "Added", "Improved" or "Removed"', () => {
+      assert.deepEqual(Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Added
+- Some new feature
+
+### Improved
+- Some enhancement
+
+### Removed
+- Some removed feature
+`, createVersion(2, 0, 0)), E.right(true));
+    });
+
+    it('should fail if "Added" used in a patch', () => {
+      assert.deepEqual(
+        Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Added
+- Some new feature
+`, createVersion(0, 1, 1)),
+        E.left('Changelog contains an Added or Improved section for a patch release. This should be at least a minor.')
+      );
+    });
+
+    it('should fail if "Improved" used in a patch', () => {
+      assert.deepEqual(
+        Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Improved
+- Some enhancement
+`, createVersion(0, 1, 1)),
+        E.left('Changelog contains an Added or Improved section for a patch release. This should be at least a minor.')
+      );
+    });
+
+    it('should fail if "Removed" used in a patch or minor', () => {
+      assert.deepEqual(
+        Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Removed
+- Some removed feature
+`, createVersion(0, 1, 1)),
+        E.left('Changelog contains a Removed section for a patch release. This should be at least a major.')
+      );
+
+      assert.deepEqual(
+        Changelog.checkVersion(`${preamble}
+## Unreleased
+
+### Removed
+- Some removed feature
+`, createVersion(0, 1, 0)),
+        E.left('Changelog contains a Removed section for a minor release. This should be at least a major.')
+      );
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-9211

Description of Changes:

Updates the publish command to check and fail the publish if the changelog section type does not match the release type. For example, with this change you will not be able to include an `Added` entry is something configured to release as a patch.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
