### PR TITLE
TINY-9252: Update beehive to confirm to release and print a git diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 - The `publish` command will check the changelog to ensure the sections in the release match the type of release. #TINY-9211
+- The `release` command will print out the git diff to show exactly what's been released. This can be prevented with the `--no-diff` argument. #TINY-9252
 
 ### Changed
+- The `release` command will now ask for confirmation before pushing to git. This can be skipped with the `-y/--yes` argument. #TINY-9252
 - Upgraded dependencies and removed `read-pkg` as it wasn't being used. #TINY-9229
 
 ## 0.18.0 - 2022-04-21

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "simple-git": "^3.14.0",
     "tmp": "^0.2.1",
     "tslib": "^2.1.0",
-    "yargs": "^17.6.0"
+    "yargs": "^17.6.0",
+    "yesno": "^0.4.0"
   },
   "scripts": {
     "build": "tsc",
@@ -59,6 +60,7 @@
     "mocha": "^10.0.0",
     "mocha-junit-reporter": "^2.1.0",
     "mocha-multi-reporters": "^1.5.1",
+    "mock-stdin": "^1.0.0",
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.9.1",

--- a/src/main/ts/args/BeehiveArgs.ts
+++ b/src/main/ts/args/BeehiveArgs.ts
@@ -18,6 +18,8 @@ export interface ReleaseArgs extends BaseArgs {
   readonly gitUrl: Option<string>;
   readonly allowPreReleaseDeps: boolean;
   readonly noChangelog: boolean;
+  readonly noDiff: boolean;
+  readonly yes: boolean;
 }
 
 export interface AdvanceArgs extends BaseArgs {
@@ -60,7 +62,15 @@ export const prepareArgs = (dryRun: boolean, workingDir: string, temp: Option<st
 });
 
 export const releaseArgs = (
-  dryRun: boolean, workingDir: string, temp: Option<string>, gitUrl: Option<string>, branchName: string, allowPreReleaseDeps: boolean, noChangelog: boolean
+  dryRun: boolean,
+  workingDir: string,
+  temp: Option<string>,
+  gitUrl: Option<string>,
+  branchName: string,
+  allowPreReleaseDeps: boolean,
+  noChangelog: boolean,
+  noDiff: boolean,
+  yes: boolean
 ): ReleaseArgs => ({
   kind: 'ReleaseArgs',
   dryRun,
@@ -69,7 +79,9 @@ export const releaseArgs = (
   gitUrl,
   branchName,
   allowPreReleaseDeps,
-  noChangelog
+  noChangelog,
+  noDiff,
+  yes
 });
 
 export const advanceArgs = (

--- a/src/main/ts/args/Parser.ts
+++ b/src/main/ts/args/Parser.ts
@@ -65,6 +65,19 @@ const noChangelogReleaseOptions: yargs.Options = {
   default: false
 };
 
+const noDiffOptions: yargs.Options = {
+  description: 'Prevent the git diff being logged.',
+  type: 'boolean',
+  default: false
+};
+
+const yesOptions: yargs.Options = {
+  description: 'Reply yes to any prompts.',
+  type: 'boolean',
+  default: false,
+  alias: 'y'
+};
+
 const getColumns = (): number =>
   Math.min(120, yargs.terminalWidth());
 
@@ -96,7 +109,9 @@ const argParser =
         .option('git-url', gitUrlOptions)
         .option('temp', tempOptions)
         .option('allow-pre-releases', allowPreReleaseDepsOptions)
-        .option('no-changelog', noChangelogReleaseOptions),
+        .option('no-changelog', noChangelogReleaseOptions)
+        .option('no-diff', noDiffOptions)
+        .option('yes', yesOptions),
     )
     .command(
       'advance <majorMinorOrMain>',
@@ -193,7 +208,9 @@ export const parseArgs = async (args: string[]): Promise<Option<BeehiveArgs>> =>
       gitUrl(),
       await majorMinorOrMain(),
       a['allow-pre-releases'] as boolean,
-      a['no-changelog'] as boolean
+      a['no-changelog'] as boolean,
+      a['no-diff'] as boolean,
+      a.yes as boolean
     ));
 
   } else if (cmd === 'advance') {

--- a/src/main/ts/commands/Release.ts
+++ b/src/main/ts/commands/Release.ts
@@ -1,5 +1,6 @@
 import * as O from 'fp-ts/Option';
 import { SimpleGit } from 'simple-git';
+import yesno from 'yesno';
 import { ReleaseArgs } from '../args/BeehiveArgs';
 import * as Version from '../core/Version';
 import * as Git from '../utils/Git';
@@ -57,6 +58,19 @@ export const release = async (args: ReleaseArgs): Promise<void> => {
 
   await git.add(rootModule.packageJsonFile);
   await git.commit('Branch is ready for release - setting release version');
+
+  if (!args.noDiff) {
+    console.log('Changes:');
+    const diff = await git.diff([ '--color', 'HEAD~1' ]);
+    console.log(diff);
+  }
+
+  if (!args.yes) {
+    const kontinue = await yesno({ question: `Push changes and release ${Version.versionToString(newVersion)}? (Y/n)`, defaultValue: true });
+    if (!kontinue) {
+      throw new Error('Aborted!');
+    }
+  }
 
   await Git.pushUnlessDryRun(dir, git, args.dryRun);
 };

--- a/src/test/ts/args/ParserTest.ts
+++ b/src/test/ts/args/ParserTest.ts
@@ -30,11 +30,11 @@ describe('Parser', () => {
       await fc.assert(fc.asyncProperty(fc.nat(100), fc.nat(100), async (major, minor) => {
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}` ]),
-          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false))
+          O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false, false, false))
         );
         await assert.becomes(
           parseArgs([ 'release', `${major}.${minor}`, '--dry-run' ]),
-          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false))
+          O.some(BeehiveArgs.releaseArgs(true, process.cwd(), O.none, O.none, `release/${major}.${minor}`, false, false, false, false))
         );
       }));
     });
@@ -42,7 +42,7 @@ describe('Parser', () => {
     it('succeeds for release command with main arg', async () => {
       await assert.becomes(
         parseArgs([ 'release', 'main' ]),
-        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main', false, false))
+        O.some(BeehiveArgs.releaseArgs(false, process.cwd(), O.none, O.none, 'main', false, false, false, false))
       );
     });
 

--- a/src/test/ts/commands/LifecycleTest.ts
+++ b/src/test/ts/commands/LifecycleTest.ts
@@ -28,7 +28,7 @@ describe('Lifecycle', () => {
     await git.checkout('release/0.1');
     await assertPjVersion('0.1.0-rc');
 
-    await beehiveFlow([ 'release', '0.1', '--git-url', hub.dir ]);
+    await beehiveFlow([ 'release', '0.1', '--yes', '--git-url', hub.dir ]);
     await git.pull();
     await assertPjVersion('0.1.0');
 
@@ -36,7 +36,7 @@ describe('Lifecycle', () => {
     await git.pull();
     await assertPjVersion('0.1.1-rc');
 
-    await beehiveFlow([ 'release', '0.1', '--git-url', hub.dir ]);
+    await beehiveFlow([ 'release', '0.1', '--yes', '--git-url', hub.dir ]);
     await git.pull();
     await assertPjVersion('0.1.1');
 

--- a/src/test/ts/commands/ReleaseTest.ts
+++ b/src/test/ts/commands/ReleaseTest.ts
@@ -1,13 +1,16 @@
+import * as os from 'os';
 import { describe, it } from 'mocha';
+import mockStdin from 'mock-stdin';
 import { assert } from 'chai';
 import * as Git from '../../../main/ts/utils/Git';
-import { beehiveFlow, makeBranchWithPj, readKeepAChangelogInDir, readPjVersionInDir, writeAndAddLocalFile } from './TestUtils';
+import { beehiveFlow, makeBranchWithPj, readKeepAChangelogInDir, readPjVersionInDir, wait, writeAndAddLocalFile } from './TestUtils';
 
 describe('Release', () => {
-  const runScenario = async (
+  const runConfirmScenario = async (
     branchName: string,
     version: string,
     arg: string,
+    confirm: 'yes' | 'no',
     newVersion?: string,
     dependencies: Record<string, string> = {},
     additionalArgs: string[] = []
@@ -15,10 +18,37 @@ describe('Release', () => {
     const hub = await Git.initInTempFolder(true);
     const { dir, git } = await Git.cloneInTempFolder(hub.dir);
     await makeBranchWithPj(git, branchName, dir, 'test-release', version, newVersion, dependencies);
-    await beehiveFlow([ 'release', arg, '--working-dir', dir, ...additionalArgs ]);
+    const stdin = mockStdin.stdin();
+    const result = beehiveFlow([ 'release', arg, '--working-dir', dir, ...additionalArgs ]);
+    if (!additionalArgs.includes('-y')) {
+      // Wait 750ms before adding input to ensure it's ready (takes ~600ms)
+      await wait(750);
+      stdin.send(confirm + os.EOL);
+    }
+    stdin.end();
+    await result;
     await git.pull();
     return dir;
   };
+
+  const runScenario = async (
+    branchName: string,
+    version: string,
+    arg: string,
+    newVersion?: string,
+    dependencies: Record<string, string> = {},
+    additionalArgs: string[] = []
+  ) =>
+    runConfirmScenario(branchName, version, arg, 'yes', newVersion, dependencies, [ ...additionalArgs, '-y' ]);
+
+  it('waits for a user to confirm the release by default', async () => {
+    const dir = await runConfirmScenario('main', '0.0.1-rc', 'main', 'yes');
+    await assert.becomes(readPjVersionInDir(dir), '0.0.1');
+  });
+
+  it('stops releasing if aborted when confirming', async () => {
+    await assert.isRejected(runConfirmScenario('main', '0.0.1-rc', 'main', 'no'));
+  });
 
   it('releases rc version from main', async () => {
     const dir = await runScenario('main', '0.0.1-rc', 'main');
@@ -36,7 +66,7 @@ describe('Release', () => {
   });
 
   it('releases if --allow-pre-releases is enabled when a pre-release dependency exists', async () => {
-    const dir = await runScenario('main', '0.1.0-rc', 'main', undefined, { dep1: '~3.2.0-rc' }, [ '--allow-pre-releases' ]);
+    const dir = await runScenario('main', '0.1.0-rc', 'main', undefined, { dep1: '~3.2.0-rc' }, [ '-y', '--allow-pre-releases' ]);
     await assert.becomes(readPjVersionInDir(dir), '0.1.0');
   });
 

--- a/src/test/ts/commands/TestUtils.ts
+++ b/src/test/ts/commands/TestUtils.ts
@@ -13,6 +13,9 @@ import * as Files from '../../../main/ts/utils/Files';
 import * as Git from '../../../main/ts/utils/Git';
 import * as ObjUtils from '../../../main/ts/utils/ObjUtils';
 
+export const wait = (time: number) =>
+  new Promise((resolve) => setTimeout(resolve, time));
+
 const writePackageJson = async (
   dir: string, packageName: string, version: string, dependencies: Record<string, string> = {}, address: string = 'blah://frog'
 ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,6 +2959,11 @@ mocha@^10.0.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mock-stdin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
+  integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4460,6 +4465,11 @@ yargs@^17.6.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yesno@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/yesno/-/yesno-0.4.0.tgz#5d674f14d339f0bd4b0edc47f899612c74fcd895"
+  integrity sha512-tdBxmHvbXPBKYIg81bMCB7bVeDmHkRzk5rVJyYYXurwKkHq/MCd8rz4HSJUP7hW0H2NlXiq8IFiWvYKEHhlotA==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Related Ticket: TINY-9252

Description of Changes:
* Show the git diff for the entire changes when doing a release to make sure you know what is being changed. This can be disabled with `--no-diff` if needed.
* Ask the user for confirmation to release after printing the diff to confirm everything is good. This can be skipped by adding `-y` or `--yes`. The main aim is to save us having to run twice via `--dry-run`.

For example, here's the output of how this looks having run it against `main` in dry run mode:
```
Running: release  (dry-run)
Cloning git@github.com:tinymce/beehive-flow.git to /var/folders/zz/9hp_j6756wv87w8d25jd8plw0000gn/T/beehive-flow-7103-ATR8qcknni4p
Checking out branch: main
Updating version from 0.19.0-rc to 0.19.0
Setting version in /var/folders/zz/9hp_j6756wv87w8d25jd8plw0000gn/T/beehive-flow-7103-ATR8qcknni4p/package.json to: 0.19.0
Changing unreleased changelog header to 0.19.0 - 2022-10-14
Saving changes to /var/folders/zz/9hp_j6756wv87w8d25jd8plw0000gn/T/beehive-flow-7103-ATR8qcknni4p/CHANGELOG.md
Changes:
diff --git a/CHANGELOG.md b/CHANGELOG.md
index f42376d..f4a3482 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.19.0 - 2022-10-14
+
 ### Added
 - Keep A Changelog files will now get a release header added automatically. This can be prevented with the `--no-changelog` argument. #TINY-9204
 
diff --git a/package.json b/package.json
index 1feb958..f967975 100644
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "version": "0.19.0-rc",
+  "version": "0.19.0",
   "name": "@tinymce/beehive-flow"
 }

Push changes and release 0.19.0? (Y/n) n
Aborted!

```

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
