### PR TITLE
TINY-11411: Bump codeql version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,15 +32,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 
 standardProperties()
 
-tinyPods.node() {
+tinyPods.node(tag: '20') {
   stage("deps") {
     yarnInstall()
   }


### PR DESCRIPTION
Related Ticket: TINY-11411

Description of Changes:
* Bump codeql version

Pre-checks:
* [X] Changelog entry added
* [X] package.json version bumped (if first change of new major/minor)
* [X] Tests have been added (if applicable)

Before merging:
* [X] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
